### PR TITLE
Provide a better way to export public keys

### DIFF
--- a/docs/source/jwk.rst
+++ b/docs/source/jwk.rst
@@ -74,7 +74,7 @@ Create a 2048bit RSA keypair::
 
 Create a P-256 EC keypair and export the public key::
     >>> key = jwk.JWK(generate='EC', crv='P-256')
-    >>> key.export_public()
+    >>> key.export(private_key=False)
     '{"y":"VYlYwBfOTIICojCPfdUjnmkpN-g-lzZKxzjAoFmDRm8",
       "x":"3mdE0rODWRju6qqU01Kw5oPYdNxBOMisFvJFH1vEu9Q",
       "crv":"P-256","kty":"EC"}'

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -320,8 +320,14 @@ class JWK(object):
                                               ' "key_ops" values specified at'
                                               ' the same time')
 
-    def export(self):
-        """Exports the key in the standard JSON format"""
+    def export(self, private_key=True):
+        """Exports the key in the standard JSON format.
+
+        :param private_key(bool): Whether to export the private key.
+                                  Defaults to True.
+        """
+        if private_key is not True:
+            return self.export_public()
         d = dict()
         d.update(self._params)
         d.update(self._key)
@@ -329,7 +335,10 @@ class JWK(object):
         return json_encode(d)
 
     def export_public(self):
-        """Exports the public key in the standard JSON format"""
+        """Exports the public key in the standard JSON format.
+           This function is deprecated and maintained only for
+           backwards compatibility, use export(private_key=False)
+           instead."""
         pub = {}
         preg = JWKParamsRegistry
         for name in preg:
@@ -485,11 +494,15 @@ class JWKSet(set):
             raise TypeError('Only JWK objects are valid elements')
         set.add(self, elem)
 
-    def export(self):
-        """Exports the set using the standard JSON format"""
+    def export(self, private_keys=True):
+        """Exports the set using the standard JSON format
+
+        :param private_key(bool): Whether to export private keys.
+                                  Defaults to True.
+        """
         keys = list()
         for jwk in self:
-            keys.append(json_decode(jwk.export()))
+            keys.append(json_decode(jwk.export(private_keys)))
         return json_encode({'keys': keys})
 
     def get_key(self, kid):


### PR DESCRIPTION
This makes the same call export just the public keys if private_key is
set to False.

In hindsight if we had this from the start the default would be to export
public keys and you'd have to actively pass a True value to export private
ones, but I do not want to break applications now.

Not only this API it is somewhat more natural (with the above caveat), it also
allows to do exactlyu the same for JWK Sets with substantially no code
changes.

Signed-off-by: Simo Sorce <simo@redhat.com>