### PR TITLE
Allow to pass in dictionaries for headers

### DIFF
--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -864,10 +864,16 @@ class JWE(object):
         if aad:
             self.objects['aad'] = aad
         if protected:
-            json_decode(protected)  # check header encoding
+            if isinstance(protected, dict):
+                protected = json_encode(protected)
+            else:
+                json_decode(protected)  # check header encoding
             self.objects['protected'] = protected
         if unprotected:
-            json_decode(unprotected)  # check header encoding
+            if isinstance(unprotected, dict):
+                unprotected = json_encode(unprotected)
+            else:
+                json_decode(unprotected)  # check header encoding
             self.objects['unprotected'] = unprotected
         if algs:
             self.allowed_algs = algs
@@ -967,6 +973,9 @@ class JWE(object):
             raise ValueError('Missing plaintext')
         if not isinstance(self.plaintext, bytes):
             raise ValueError("Plaintext must be 'bytes'")
+
+        if isinstance(header, dict):
+            header = json_encode(header)
 
         jh = self._get_jose_header(header)
         alg, enc = self._get_alg_enc_from_headers(jh)

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -215,6 +215,8 @@ class JWSCore(object):
         self.key = key
 
         if header is not None:
+            if isinstance(header, dict):
+                header = json_encode(header)
             self.protected = base64url_encode(header.encode('utf-8'))
         else:
             self.protected = ''
@@ -517,12 +519,16 @@ class JWS(object):
 
         p = dict()
         if protected:
+            if isinstance(protected, dict):
+                protected = json_encode(protected)
             p = json_decode(protected)
             # TODO: allow caller to specify list of headers it understands
             if 'crit' in p:
                 self._check_crit(p['crit'])
 
         if header:
+            if isinstance(header, dict):
+                header = json_encode(header)
             h = json_decode(header)
             p = self._merge_headers(p, h)
 


### PR DESCRIPTION
Where it makes sense, allow to pass in a dictionary for the various headers
and auto-encode them as needed.

Resolves #53
