### PR TITLE
Allow to pass 'alg' as an argument for key generation

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -1105,12 +1105,16 @@ class JWA(object):
     }
 
     @classmethod
+    def instantiate_alg(cls, name, use=None):
+        alg = cls.algorithms_registry[name]
+        if use is not None and alg.algorithm_use != use:
+            raise KeyError
+        return alg()
+
+    @classmethod
     def signing_alg(cls, name):
         try:
-            obj = cls.algorithms_registry[name]()
-            if obj.algorithm_use != 'sig':
-                raise KeyError()
-            return obj
+            return cls.instantiate_alg(name, use='sig')
         except KeyError:
             raise InvalidJWAAlgorithm(
                 '%s is not a valid Signign algorithm name' % name)
@@ -1118,10 +1122,7 @@ class JWA(object):
     @classmethod
     def keymgmt_alg(cls, name):
         try:
-            obj = cls.algorithms_registry[name]()
-            if obj.algorithm_use != 'kex':
-                raise KeyError()
-            return obj
+            return cls.instantiate_alg(name, use='kex')
         except KeyError:
             raise InvalidJWAAlgorithm(
                 '%s is not a valid Key Management algorithm name' % name)
@@ -1129,10 +1130,7 @@ class JWA(object):
     @classmethod
     def encryption_alg(cls, name):
         try:
-            obj = cls.algorithms_registry[name]()
-            if obj.algorithm_use != 'enc':
-                raise KeyError()
-            return obj
+            return cls.instantiate_alg(name, use='enc')
         except KeyError:
             raise InvalidJWAAlgorithm(
                 '%s is not a valid Encryption algorithm name' % name)

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -198,8 +198,12 @@ class TestJWK(unittest.TestCase):
         jwk.JWK.generate(kty='oct', size=256)
         jwk.JWK.generate(kty='RSA', size=4096)
         jwk.JWK.generate(kty='EC', curve='P-521')
-        k = jwk.JWK.generate(kty='oct', size=256, kid='MySymmetricKey')
+        k = jwk.JWK.generate(kty='oct', alg='A192KW', kid='MySymmetricKey')
         self.assertEqual(k.key_id, 'MySymmetricKey')
+        self.assertEqual(len(base64url_decode(k.get_op_key('encrypt'))), 24)
+        jwk.JWK.generate(kty='RSA', alg='RS256')
+        k = jwk.JWK.generate(kty='RSA', size=4096, alg='RS256')
+        self.assertEqual(k.get_op_key('encrypt').key_size, 4096)
 
     def test_export_public_keys(self):
         k = jwk.JWK(**RSAPrivateKey)


### PR DESCRIPTION
This allows to automatically get a key of adequate size for the selected algorithm.

Resolves #50, depends on #58 

@tiran please check