### PR TITLE
Always use bit sizes for keys through the code

### DIFF
--- a/jwcrypto/common.py
+++ b/jwcrypto/common.py
@@ -56,7 +56,7 @@ class InvalidCEKeyLength(Exception):
     """
 
     def __init__(self, expected, obtained):
-        msg = 'Expected key of length %d, got %d' % (expected, obtained)
+        msg = 'Expected key of length %d bits, got %d' % (expected, obtained)
         super(InvalidCEKeyLength, self).__init__(msg)
 
 

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -223,7 +223,7 @@ class JWE(object):
         if header:
             rec['header'] = header
 
-        wrapped = alg.wrap(key, enc.key_size, self.cek, jh)
+        wrapped = alg.wrap(key, enc.wrap_key_size, self.cek, jh)
         self.cek = wrapped['cek']
 
         if 'ek' in wrapped:
@@ -350,7 +350,8 @@ class JWE(object):
         if 'aad' in self.objects:
             aad += '.' + base64url_encode(self.objects['aad'])
 
-        cek = alg.unwrap(key, enc.key_size, ppe.get('encrypted_key', b''), jh)
+        cek = alg.unwrap(key, enc.wrap_key_size,
+                         ppe.get('encrypted_key', b''), jh)
         data = enc.decrypt(cek, aad.encode('utf-8'),
                            self.objects['iv'],
                            self.objects['ciphertext'],

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -238,7 +238,7 @@ class JWK(object):
                 alg = JWA.instantiate_alg(params['alg'])
             except KeyError:
                 raise ValueError("Invalid 'alg' parameter")
-            size = alg.min_key_size
+            size = alg.keysize
         return size
 
     def _generate_oct(self, params):


### PR DESCRIPTION
Makes all the JWA code and error messages use bit sizes for key material.

Resolves #49, depends on #58

@tiran please check
