### PR TITLE
Add 'cryptography' to requirements in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-cryptography >= 0.7.2

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     data_files = [('share/doc/jwcrypto', ['LICENSE', 'README.md'])],
+    install_requires = [
+        'cryptography >= 0.7.2',
+    ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ setenv =
 deps =
     pytest
     coverage
-    -r{toxinidir}/requirements.txt
 sitepackages = True
 commands =
     {envpython} -m coverage run -m pytest --capture=no --strict {posargs}
@@ -18,7 +17,6 @@ commands =
 basepython = python2.7
 deps =
     pylint
-    -r{toxinidir}/requirements.txt
 sitepackages = True
 commands =
     {envpython} -m pylint -d c,r,i,W0613 -r n -f colorized --notes= --disable=star-args ./jwcrypto
@@ -57,7 +55,6 @@ basepython = python2.7
 changedir = docs/source
 deps =
     sphinx < 1.3.0
-    -r{toxinidir}/requirements.txt
 commands =
     sphinx-build -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 


### PR DESCRIPTION
This is so that you can add just jwcrypto to the requirements of a downstream project and have it install everything needed -- previously you would also have to add cryptography yourself.

Since this was the only thing in requirements.txt I have removed the file.

Fixes #69.