### PR TITLE
Set claims after reg_claims

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -191,14 +191,14 @@ class JWT(object):
         if header:
             self.header = header
 
-        if claims:
-            self.claims = claims
-
         if default_claims is not None:
             self._reg_claims = default_claims
 
         if check_claims is not None:
             self._check_claims = check_claims
+
+        if claims:
+            self.claims = claims
 
         if jwt is not None:
             self.deserialize(jwt, key)


### PR DESCRIPTION
If self.claims is setted before `self._reg_claims`, then `self._add_default_claims` will never do its job in the  `__init__` code : 
```python
    @claims.setter
    def claims(self, c):
        if isinstance(c, dict):
            self._add_default_claims(c)
            self._claims = json_encode(c)
        else:
            self._claims = c
```
```python
    def _add_default_claims(self, claims):
        if self._reg_claims is None:
            return
...
```

By setting `self.claims` after `self._reg_claims`, it should be OK.

Current workaround is to initialize the token with claims=None and default_claims (!= None), and then set the claims, which is a little counter-inituitive (I have to check the code several times to understand why the default claims were not setted as expected).