### PR TITLE
Fix typo in jwk chapter of docs

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -166,7 +166,7 @@ class JWK(object):
 
     This object represent a Key.
     It must be instantiated by using the standard defined key/value pairs
-    as arguents of the initialization function.
+    as arguments of the initialization function.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This pull request fixes a minor typo in the `jwcrypto.jwk.JWK` docstrings.