### PR TITLE
Fix error interpolation on nonstandard jwt claims

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -398,7 +398,7 @@ class JWT(object):
             else:
                 if value is not None and value != claims[name]:
                     raise JWTInvalidClaimValue(
-                        "Invalid '%s' value. Expected '%d' got '%d'" % (
+                        "Invalid '%s' value. Expected '%s' got '%s'" % (
                             name, value, claims[name]))
 
     def make_signed_token(self, key):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1018,6 +1018,25 @@ class TestJWT(unittest.TestCase):
         keyset.add(key)
         jwt.JWT(jwt=token, key=keyset, check_claims={'exp': 1300819380})
 
+    def test_invalid_claim_type(self):
+        key = jwk.JWK(**E_A2_key)
+        claims = {"testclaim": "test"}
+        claims.update(A1_claims)
+        t = jwt.JWT(A1_header, claims)
+        t.make_encrypted_token(key)
+        token = t.serialize()
+
+        # Wrong string
+        self.assertRaises(jwt.JWTInvalidClaimValue, jwt.JWT, jwt=token,
+                          key=key, check_claims={"testclaim": "ijgi"})
+
+        # Wrong type
+        self.assertRaises(jwt.JWTInvalidClaimValue, jwt.JWT, jwt=token,
+                          key=key, check_claims={"testclaim": 123})
+
+        # Correct
+        jwt.JWT(jwt=token, key=key, check_claims={"testclaim": "test"})
+
 
 class ConformanceTests(unittest.TestCase):
 


### PR DESCRIPTION
If the claim passed was not one of sub, aud, iat, etc. then passing a string as a value to check_claims would raise an error if it was not an integer