### PR TITLE
Add function to get a public only JWK

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -405,6 +405,10 @@ class JWK(object):
         It fails if one is not available like when this function
         is called on a symmetric key.
         """
+        pub = self._public_params()
+        return json_encode(pub)
+
+    def _public_params(self):
         if not self.has_public:
             raise InvalidJWKType("No public key available")
         pub = {}
@@ -417,7 +421,7 @@ class JWK(object):
         for param in reg:
             if reg[param][1] == 'Public':
                 pub[param] = self._key[param]
-        return json_encode(pub)
+        return pub
 
     def _export_all(self):
         d = dict()
@@ -438,6 +442,10 @@ class JWK(object):
         if self.is_symmetric:
             return self._export_all()
         raise InvalidJWKType("Not a symmetric key")
+
+    def public(self):
+        pub = self._public_params()
+        return JWK(**pub)
 
     @property
     def has_public(self):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -377,6 +377,21 @@ class TestJWK(unittest.TestCase):
         self.assertFalse(pubkey.has_private)
         self.assertEqual(prikey.key_id, pubkey.key_id)
 
+    def test_public(self):
+        key = jwk.JWK.from_pem(RSAPrivatePEM, password=RSAPrivatePassword)
+        self.assertTrue(key.has_public)
+        self.assertTrue(key.has_private)
+        pubkey = key.public()
+        self.assertTrue(pubkey.has_public)
+        self.assertFalse(pubkey.has_private)
+        # finally check public works
+        e = jwe.JWE('plaintext', '{"alg":"RSA-OAEP","enc":"A256GCM"}')
+        e.add_recipient(pubkey)
+        enc = e.serialize()
+        d = jwe.JWE()
+        d.deserialize(enc, key)
+        self.assertEqual(d.payload, b'plaintext')
+
 
 # RFC 7515 - A.1
 A1_protected = \


### PR DESCRIPTION
This makes it simpler to get a JWK that contains excluively a pulic
key from an existing JWK. It fails if no public key is available in
the source JWK.
Only known public elements are returned. "Unknown" attributes are
not copied over.

Resolves #99