### PR TITLE
Fix misleading aud mismatch error message

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -384,8 +384,8 @@ class JWT(object):
                         if value in claims[name]:
                             continue
                     raise JWTInvalidClaimValue(
-                        "Invalid '%s' value. Expected '%s' in '%s'" % (
-                            name, value, claims[name]))
+                        "Invalid '%s' value. Expected '%s' to be in '%s'" % (
+                            name, claims[name], value))
 
             elif name == 'exp':
                 if value is not None:


### PR DESCRIPTION
If the 'aud' value was wrong in a jwt, then the error messages was a bit wrong. For example, if we expected the audience to be one of `["abc.com", "123.com"]` but we gave it `"www.google.com"`, then the error message would say `Expected ["abc.com", "123.com"] in "www.google.com"` which is the wrong way round.

This just makes it to the error message prints out those things in the right order.
