### PR TITLE
Fixing "A128KW" under "_EcdhEsAes256Kw"

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -828,7 +828,7 @@ class _EcdhEsAes192Kw(_EcdhEs):
 class _EcdhEsAes256Kw(_EcdhEs):
 
     name = 'ECDH-ES+A256KW'
-    description = 'ECDH-ES using Concat KDF and "A128KW" wrapping'
+    description = 'ECDH-ES using Concat KDF and "A256KW" wrapping'
     keysize = 256
     algorithm_usage_location = 'alg'
     algorithm_use = 'kex'


### PR DESCRIPTION
There was a typo in the "_EcdhEsAes256Kw" class. I have changed "A128KW" in the description for the class to become "A256KW" in accordance with the algorithm.