### PR TITLE
Fix JWK.from_json #130

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -429,6 +429,7 @@ class JWK(object):
                         raise InvalidJWKValue('Incompatible "use" and'
                                               ' "key_ops" values specified at'
                                               ' the same time')
+        return self
 
     @classmethod
     def from_json(cls, key):
@@ -674,6 +675,7 @@ class JWK(object):
             self._import_pyca_pub_ec(key)
         else:
             raise InvalidJWKValue('Unknown key object %r' % key)
+        return self
 
     def import_from_pem(self, data, password=None):
         """Imports a key from data loaded from a PEM file.
@@ -704,6 +706,7 @@ class JWK(object):
 
         self.import_from_pyca(key)
         self._params['kid'] = self.thumbprint()
+        return self
 
     def export_to_pem(self, private_key=False, password=False):
         """Exports keys to a data buffer suitable to be stored as a PEM file.
@@ -743,8 +746,7 @@ class JWK(object):
     @classmethod
     def from_pyca(cls, key):
         obj = cls()
-        obj.import_from_pyca(key)
-        return obj
+        return obj.import_from_pyca(key)
 
     @classmethod
     def from_pem(cls, data, password=None):
@@ -755,8 +757,7 @@ class JWK(object):
         :param password(bytes): An optional password to unwrap the key.
         """
         obj = cls()
-        obj.import_from_pem(data, password)
-        return obj
+        return obj.import_from_pem(data, password)
 
     def thumbprint(self, hashalg=hashes.SHA256()):
         """Returns the key thumbprint as specified by RFC 7638.
@@ -853,7 +854,6 @@ class JWKSet(dict):
                     self['keys'].add(JWK(**jwk))
             else:
                 self[k] = v
-
         return self
 
     @classmethod

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -311,6 +311,11 @@ class TestJWK(unittest.TestCase):
         self.assertRaises(jwk.InvalidJWKValue,
                           jwk.JWK.from_pyca, dict())
 
+    def test_jwk_from_json(self):
+        k = jwk.JWK.generate(kty='oct', size=256)
+        y = jwk.JWK.from_json(k.export())
+        self.assertEqual(k.export(), y.export())
+
     def test_jwkset(self):
         k = jwk.JWK(**RSAPrivateKey)
         ks = jwk.JWKSet()


### PR DESCRIPTION
Instead of changing `JWK.from_json` from 
```
return obj.importXX
```
 to 
```
obj.import
return obj
```

I found better to change the signature of the `importXX` functions to `return self`.