### PR TITLE
RFC 8037 - Support for Ed25519, Ed448

### DIFF
--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -29,7 +29,8 @@ default_allowed_algs = [
     'HS256', 'HS384', 'HS512',
     'RS256', 'RS384', 'RS512',
     'ES256', 'ES384', 'ES512',
-    'PS256', 'PS384', 'PS512']
+    'PS256', 'PS384', 'PS512',
+    'EdDSA']
 """Default allowed algorithms"""
 
 


### PR DESCRIPTION
Support for Ed25519 and Ed448, allowing signing and verification.

Some code cherry-picked from [Simo5's rfc8037 branch](https://github.com/simo5/jwcrypto/tree/rfc8037).