### PR TITLE
Add the ability to verify 'none' signatures.

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -161,7 +161,8 @@ class _RawNone(_RawJWS):
         return ''
 
     def verify(self, key, payload, signature):
-        raise InvalidSignature('The "none" signature cannot be verified')
+        if key.key_type != 'oct' or key.get_op_key() != '':
+            raise InvalidSignature('The "none" signature cannot be verified')
 
 
 class _HS256(_RawHMAC, JWAAlgorithm):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -712,8 +712,7 @@ class TestJWS(unittest.TestCase):
                           self.check_sign, A5_example)
         a5_bis = {'allowed_algs': ['none']}
         a5_bis.update(A5_example)
-        with self.assertRaises(jws.InvalidJWSSignature):
-            self.check_sign(a5_bis)
+        self.check_sign(a5_bis)
 
     def test_A6(self):
         s = jws.JWS(A6_example['payload'])
@@ -1404,6 +1403,19 @@ class ConformanceTests(unittest.TestCase):
         check = jwe.JWE()
         check.deserialize(enc, key)
         self.assertEqual(b'plain', check.payload)
+
+    def test_none_key(self):
+        e = "eyJhbGciOiJub25lIn0." + \
+            "eyJpc3MiOiJqb2UiLCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZX0."
+        token = jwt.JWT(algs=['none'])
+        k = jwk.JWK(generate='oct', size=0)
+        token.deserialize(jwt=e, key=k)
+        self.assertEqual(json_decode(token.claims),
+                         {"iss": "joe", "http://example.com/is_root": True})
+        with self.assertRaises(KeyError):
+            token = jwt.JWT()
+            token.deserialize(jwt=e)
+            json_decode(token.claims)
 
 
 class JWATests(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
 deps =
     pytest
     coverage
-sitepackages = True
+#sitepackages = True
 commands =
     {envpython} -bb -m coverage run -m pytest --capture=no --strict {posargs}
     {envpython} -m coverage report -m
@@ -17,7 +17,7 @@ commands =
 basepython = python2.7
 deps =
     pylint
-sitepackages = True
+#sitepackages = True
 commands =
     {envpython} -m pylint -d c,r,i,W0613 -r n -f colorized --notes= --disable=star-args ./jwcrypto
 


### PR DESCRIPTION
Apparently this is required by OpenID Connect as an option:
https://openid.net/specs/openid-connect-core-1_0.html#RequestObject

In order to avoid accidental use of the None algoritm, which is disabled
by default but easy to casually enable, add the requirement to pass a
"None Key".
The none key clearly indicates that the user really wants to allow the
'none' algorithm to be used.

The "None Key" is an 'oct' key with key size of 0.

Example:
```
>>> from jwcrypto import jwk,jwt
>>> e="eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZX0."
>>> k=jwk.JWK(generate='oct', size=0)
>>> E=jwt.JWT(algs=['none'])
>>> E.deserialize(jwt=e, key=k)
>>> E.claims
u'{"iss":"joe","http://example.com/is_root":true}'
```

Fixes #163