### PR TITLE
Derive okp key type on import

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -455,10 +455,16 @@ class JWK(object):
                                   'OKP key type' % params['crv'])
         self._import_pyca_pri_okp(key, **params)
 
+    def _okp_curve_from_pyca_key(self, key):
+        for name, val in iteritems(_OKP_CURVES_TABLE):
+            if isinstance(key, (val.pubkey, val.privkey)):
+                return name
+        raise InvalidJWKValue('Invalid OKP Key object %r' % key)
+
     def _import_pyca_pri_okp(self, key, **params):
         params.update(
             kty='OKP',
-            crv=params['crv'],
+            crv=self._okp_curve_from_pyca_key(key),
             d=base64url_encode(key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.Raw,
@@ -472,10 +478,10 @@ class JWK(object):
     def _import_pyca_pub_okp(self, key, **params):
         params.update(
             kty='OKP',
-            crv=params['crv'],
+            crv=self._okp_curve_from_pyca_key(key),
             x=base64url_encode(key.public_bytes(
                 serialization.Encoding.Raw,
-                serialization.PrivateFormat.Raw))
+                serialization.PublicFormat.Raw))
         )
         self.import_key(**params)
 

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -282,6 +282,16 @@ PrivateKeys_secp256k1 = {
     ]
 }
 
+Ed25519PrivatePEM = b"""-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIEh4ImJiiZgSNg9J9I+Z5toHKh6LDO2MCbSYNZTkMXDU
+-----END PRIVATE KEY-----
+"""
+
+Ed25519PublicPEM = b"""-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAlsRcb1mVVIUcDjNqZU27N+iPXihH1EQDa/O3utHLtqc=
+-----END PUBLIC KEY-----
+"""
+
 
 class TestJWK(unittest.TestCase):
     def test_create_pubKeys(self):
@@ -493,6 +503,22 @@ class TestJWK(unittest.TestCase):
             self.assertEqual(
                 k.thumbprint(),
                 PublicKeys_EdDsa['thumbprints'][i])
+
+    def test_pem_okp(self):
+        payload = b'Imported private Ed25519'
+        prikey = jwk.JWK.from_pem(Ed25519PrivatePEM)
+        self.assertTrue(prikey.has_private)
+        self.assertTrue(prikey.has_public)
+        s = jws.JWS(payload)
+        s.add_signature(prikey, None, {'alg': 'EdDSA'}, None)
+        sig = s.serialize()
+        pubkey = jwk.JWK.from_pem(Ed25519PublicPEM)
+        self.assertTrue(pubkey.has_public)
+        self.assertFalse(pubkey.has_private)
+        c = jws.JWS()
+        c.deserialize(sig, pubkey, alg="EdDSA")
+        self.assertTrue(c.objects['valid'])
+        self.assertEqual(c.payload, payload)
 
 
 # RFC 7515 - A.1


### PR DESCRIPTION
Do not require a crv param to be passed we have enoug info on our own.

Fixes #176