### PR TITLE
Fix some documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ JWCrypto
 ========
 
 An implementation of the JOSE Working Group documents:
-RFC 7515 - JSON Web Signature (JWS)
-RFC 7516 - JSON Web Encryption (JWE)
-RFC 7517 - JSON Web Key (JWK)
-RFC 7518 - JSON Web Algorithms (JWA)
-RFC 7519 - JSON Web Token (JWT)
-RFC 7520 - Examples of Protecting Content Using JSON Object Signing and
-Encryption (JOSE)
+- RFC 7515 - JSON Web Signature (JWS)
+- RFC 7516 - JSON Web Encryption (JWE)
+- RFC 7517 - JSON Web Key (JWK)
+- RFC 7518 - JSON Web Algorithms (JWA)
+- RFC 7519 - JSON Web Token (JWT)
+- RFC 7520 - Examples of Protecting Content Using JSON Object Signing and
+  Encryption (JOSE)
 
 Documentation
 =============

--- a/docs/source/jwk.rst
+++ b/docs/source/jwk.rst
@@ -69,10 +69,10 @@ Export the key with::
     >>> key.export()
     '{"k":"X6TBlwY2so8EwKZ2TFXM7XHSgWBKQJhcspzYydp5Y-o","kty":"oct"}'
 
-Create a 2048bit RSA keypair::
+Create a 2048bit RSA key pair::
     >>> jwk.JWK.generate(kty='RSA', size=2048)
 
-Create a P-256 EC keypair and export the public key::
+Create a P-256 EC key pair and export the public key::
     >>> key = jwk.JWK.generate(kty='EC', crv='P-256')
     >>> key.export(private_key=False)
     '{"y":"VYlYwBfOTIICojCPfdUjnmkpN-g-lzZKxzjAoFmDRm8",

--- a/docs/source/jwt.rst
+++ b/docs/source/jwt.rst
@@ -3,7 +3,7 @@ JSON Web Token (JWT)
 
 The jwt Module implements the `JSON Web Token`_ standard.
 A JSON Web Token is represented by a JWT object, related utility classes and
-functions are availbale in this module too.
+functions are available in this module too.
 
 .. _JSON Web Token: http://tools.ietf.org/html/rfc7519
 

--- a/jwcrypto/common.py
+++ b/jwcrypto/common.py
@@ -91,7 +91,7 @@ class InvalidJWEKeyType(JWException):
     """Invalid JWE Key Type.
 
     This exception is raised when the provided JWK Key does not match
-    the type required by the sepcified algorithm.
+    the type required by the specified algorithm.
     """
 
     def __init__(self, expected, obtained):
@@ -103,7 +103,7 @@ class InvalidJWEKeyLength(JWException):
     """Invalid JWE Key Length.
 
     This exception is raised when the provided JWK Key does not match
-    the length required by the sepcified algorithm.
+    the length required by the specified algorithm.
     """
 
     def __init__(self, expected, obtained):

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -284,13 +284,13 @@ class JWE(object):
                         "is set" % invalid)
             if 'protected' not in self.objects:
                 raise InvalidJWEOperation(
-                    "Can't use compat encoding without protected headers")
+                    "Can't use compact encoding without protected headers")
             else:
                 ph = json_decode(self.objects['protected'])
                 for required in 'alg', 'enc':
                     if required not in ph:
                         raise InvalidJWEOperation(
-                            "Can't use compat encoding, '%s' must be in the "
+                            "Can't use compact encoding, '%s' must be in the "
                             "protected header" % required)
             if 'recipients' in self.objects:
                 if len(self.objects['recipients']) != 1:
@@ -438,7 +438,7 @@ class JWE(object):
          If a key is provided a decryption step will be attempted after
          the object is successfully deserialized.
 
-        :raises InvalidJWEData: if the raw object is an invaid JWE token.
+        :raises InvalidJWEData: if the raw object is an invalid JWE token.
         :raises InvalidJWEOperation: if the decryption fails.
         """
 

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -148,7 +148,7 @@ JWKParamsRegistry = {
     'x5t#S256': JWKParameter('X.509 Certificate SHA-256 Thumbprint',
                              True, None, None)
 }
-"""Regstry of valid key parameters"""
+"""Registry of valid key parameters"""
 
 # RFC 7518 - 7.6 , RFC 8037 - 5
 # secp256k1 - https://tools.ietf.org/html/draft-ietf-cose-webauthn-algorithms
@@ -281,7 +281,7 @@ class JWK(object):
         always be provided and its value must be a valid one as defined
         by the 'IANA JSON Web Key Types registry' and specified in the
         :data:`JWKTypesRegistry` variable. The valid key parameters per
-        key type are defined in the :data:`JWKValuesregistry` variable.
+        key type are defined in the :data:`JWKValuesRegistry` variable.
 
         To generate a new random key call the class method generate() with
         the appropriate 'kty' parameter, and other parameters as needed (key
@@ -296,7 +296,7 @@ class JWK(object):
         Deprecated:
         Alternatively if the 'generate' parameter is provided, with a
         valid key type as value then a new key will be generated according
-        to the defaults or provided key strenght options (type specific).
+        to the defaults or provided key strength options (type specific).
 
         :raises InvalidJWKType: if the key type is invalid
         :raises InvalidJWKValue: if incorrect or inconsistent parameters
@@ -579,7 +579,7 @@ class JWK(object):
     def export(self, private_key=True, as_dict=False):
         """Exports the key in the standard JSON format.
         Exports the key regardless of type, if private_key is False
-        and the key is_symmetric an exceptionis raised.
+        and the key is_symmetric an exception is raised.
 
         :param private_key(bool): Whether to export the private key.
                                   Defaults to True.
@@ -786,12 +786,12 @@ class JWK(object):
             raise NotImplementedError
 
     def get_op_key(self, operation=None, arg=None):
-        """Get the key object associated to the requested opration.
+        """Get the key object associated to the requested operation.
         For example the public RSA key for the 'verify' operation or
         the private EC key for the 'decrypt' operation.
 
         :param operation: The requested operation.
-         The valid set of operations is availble in the
+         The valid set of operations is available in the
          :data:`JWKOperationsRegistry` registry.
         :param arg: an optional, context specific, argument
          For example a curve name.
@@ -955,7 +955,7 @@ class _JWKkeys(set):
 class JWKSet(dict):
     """A set of JWK objects.
 
-    Inherits from the standard 'dict' bultin type.
+    Inherits from the standard 'dict' builtin type.
     Creates a special key 'keys' that is of a type derived from 'set'
     The 'keys' attribute accepts only :class:`jwcrypto.jwk.JWK` elements.
     """
@@ -984,12 +984,12 @@ class JWKSet(dict):
         self['keys'].add(elem)
 
     def export(self, private_keys=True, as_dict=False):
-        """Exports a RFC 7517 keyset.
+        """Exports a RFC 7517 key set.
            Exports as json by default, or as dict if requested.
 
         :param private_key(bool): Whether to export private keys.
                                   Defaults to True.
-        :param as_dict(bool): Whether to retun a dict instead of
+        :param as_dict(bool): Whether to return a dict instead of
                               a JSON object
         """
         exp_dict = dict()
@@ -1005,9 +1005,9 @@ class JWKSet(dict):
         return json_encode(exp_dict)
 
     def import_keyset(self, keyset):
-        """Imports a RFC 7517 keyset using the standard JSON format.
+        """Imports a RFC 7517 key set using the standard JSON format.
 
-        :param keyset: The RFC 7517 representation of a JOSE Keyset.
+        :param keyset: The RFC 7517 representation of a JOSE key set.
         """
         try:
             jwkset = json_decode(keyset)
@@ -1026,9 +1026,9 @@ class JWKSet(dict):
 
     @classmethod
     def from_json(cls, keyset):
-        """Creates a RFC 7517 keyset from the standard JSON format.
+        """Creates a RFC 7517 key set from the standard JSON format.
 
-        :param keyset: The RFC 7517 representation of a JOSE Keyset.
+        :param keyset: The RFC 7517 representation of a JOSE key set.
         """
         obj = cls()
         obj.import_keyset(keyset)

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -326,7 +326,7 @@ class JWS(object):
                 except Exception as e:  # pylint: disable=broad-except
                     self.verifylog.append('Failed: [%s]' % repr(e))
         else:
-            raise InvalidJWSSignature('No signatures availble')
+            raise InvalidJWSSignature('No signatures available')
 
         if not self.is_valid:
             raise InvalidJWSSignature('Verification failed for all '
@@ -373,7 +373,7 @@ class JWS(object):
         :param alg: The signing algorithm (optional). usually the algorithm
          is known as it is provided with the JOSE Headers of the token.
 
-        :raises InvalidJWSObject: if the raw object is an invaid JWS token.
+        :raises InvalidJWSObject: if the raw object is an invalid JWS token.
         :raises InvalidJWSSignature: if the verification fails.
         """
         self.objects = dict()
@@ -518,7 +518,7 @@ class JWS(object):
          representation, otherwise generates a standard JSON format.
 
         :raises InvalidJWSOperation: if the object cannot serialized
-         with the compact representation and `compat` is True.
+         with the compact representation and `compact` is True.
         :raises InvalidJWSSignature: if no signature has been added
          to the object, or no valid signature can be found.
         """

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -162,7 +162,7 @@ class JWT(object):
          the token. A (:class:`jwcrypto.jwk.JWKSet`) can also be used.
         :param algs: An optional list of allowed algorithms
         :param default_claims: An optional dict with default values for
-         registred claims. A None value for NumericDate type claims
+         registered claims. A None value for NumericDate type claims
          will cause generation according to system time. Only the values
          from RFC 7519 - 4.1 are evaluated.
         :param check_claims: An optional dict of claims that must be
@@ -171,7 +171,7 @@ class JWT(object):
 
         Note: either the header,claims or jwt,key parameters should be
         provided as a deserialization operation (which occurs if the jwt
-        is provided will wipe any header os claim provided by setting
+        is provided) will wipe any header or claim provided by setting
         those obtained from the deserialization of the jwt token.
 
         Note: if check_claims is not provided the 'exp' and 'nbf' claims
@@ -418,7 +418,7 @@ class JWT(object):
 
         Creates a JWS token with the header as the JWS protected header and
         the claims as the payload. See (:class:`jwcrypto.jws.JWS`) for
-        details on the exceptions that may be reaised.
+        details on the exceptions that may be raised.
 
         :param key: A (:class:`jwcrypto.jwk.JWK`) key.
         """
@@ -434,7 +434,7 @@ class JWT(object):
 
         Creates a JWE token with the header as the JWE protected header and
         the claims as the plaintext. See (:class:`jwcrypto.jwe.JWE`) for
-        details on the exceptions that may be reaised.
+        details on the exceptions that may be raised.
 
         :param key: A (:class:`jwcrypto.jwk.JWK`) key.
         """
@@ -513,7 +513,7 @@ class JWT(object):
         Note: the compact parameter is provided for general compatibility
         with the serialize() functions of :class:`jwcrypto.jws.JWS` and
         :class:`jwcrypto.jwe.JWE` so that these objects can all be used
-        interchangeably. However the only valid JWT representtion is the
+        interchangeably. However the only valid JWT representation is the
         compact representation.
         """
         return self.token.serialize(compact)

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -400,7 +400,7 @@ class TestJWK(unittest.TestCase):
         ks3 = jwk.JWKSet.from_json(ks.export())
         self.assertEqual(len(ks), len(ks3))
 
-        # Test Keyset with mutiple keys
+        # Test key set with mutiple keys
         ksm = jwk.JWKSet.from_json(json_encode(PrivateKeys))
         num = 0
         for item in ksm:


### PR DESCRIPTION
Reading through the docs I found a few typos so I was hoping this might be helpful.