### PR TITLE
Make sure an empty dict is a valid JWT payload

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -199,7 +199,7 @@ class JWT(object):
         if check_claims is not None:
             self._check_claims = check_claims
 
-        if claims:
+        if claims is not None:
             self.claims = claims
 
         if jwt is not None:

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1421,6 +1421,34 @@ class TestJWT(unittest.TestCase):
         jwt.JWT(jwt=token, key=key, check_claims={"iss": "test", "exp": None,
                                                   "string_claim": "test"})
 
+    def test_empty_claims(self):
+        key = jwk.JWK().generate(kty='oct')
+
+        # empty dict is valid
+        t = jwt.JWT('{"alg":"HS256"}', {})
+        self.assertEqual('{}', t.claims)
+        t.make_signed_token(key)
+        token = t.serialize()
+
+        c = jwt.JWT()
+        c.deserialize(token, key)
+        self.assertEqual('{}', c.claims)
+
+        # empty string is not valid
+        t = jwt.JWT('{"alg":"HS256"}', '')
+        self.assertEqual('', t.claims)
+        self.assertRaises(jws.InvalidJWSObject, t.make_signed_token, key)
+
+        # but a space is fine
+        t = jwt.JWT('{"alg":"HS256"}', ' ')
+        self.assertEqual(' ', t.claims)
+        t.make_signed_token(key)
+        token = t.serialize()
+
+        c = jwt.JWT()
+        c.deserialize(token, key)
+        self.assertEqual(' ', c.claims)
+
 
 class ConformanceTests(unittest.TestCase):
 


### PR DESCRIPTION
Nowhere in the spec it says the payload must not be an empty dictionary.
It makes little sense to not have any claims, because then, what do you
claim? But that's a problem for the user, especially given the fact you
could already pas in the literal string '{}' and it would get signed.

However a completely empty string is invalid, at least one character,
even just a space is needed.

Fixes #187