### PR TITLE
Deprecate RSA1_5 and remove from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,23 @@ Documentation
 =============
 
 http://jwcrypto.readthedocs.org
+
+Deprecation Notices
+===================
+
+2020.12.11: The RSA1_5 algorithm is now considered deprecated due to numerous
+implementation issues that make it a very problematic tool to use safely.
+The algorithm can still be used but requires explicitly allowing it on object
+instantiation. If your application depends on it there are examples of how to
+re-enable RSA1_5 usage in the tests files.
+
+Note: if you enable support for `RSA1_5` and the attacker can send you chosen
+ciphertext and is able to measure the processing times of your application,
+then your application will be vulnerable to a Bleichenbacher RSA padding
+oracle, allowing the so-called "Million messages attack". That attack allows
+to decrypt intercepted messages (even if they were encrypted with RSA-OAEP) or
+forge signatures (both RSA-PKCS#1 v1.5 and RSASSA-PSS).
+
+Given JWT is generally used in tokens to sign authorization assertions or to
+encrypt private key material, this is a particularly severe issue, and must
+not be underestimated.

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -33,7 +33,7 @@ JWEHeaderRegistry = {
 
 default_allowed_algs = [
     # Key Management Algorithms
-    'RSA1_5', 'RSA-OAEP', 'RSA-OAEP-256',
+    'RSA-OAEP', 'RSA-OAEP-256',
     'A128KW', 'A192KW', 'A256KW',
     'dir',
     'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A192KW', 'ECDH-ES+A256KW',

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -440,6 +440,8 @@ class JWT(object):
         """
 
         t = JWE(self.claims, self.header)
+        if self._algs:
+            t.allowed_algs = self._algs
         t.add_recipient(key)
         self.token = t
 

--- a/jwcrypto/tests-cookbook.py
+++ b/jwcrypto/tests-cookbook.py
@@ -1110,7 +1110,8 @@ class Cookbook08JWETests(unittest.TestCase):
         plaintext = Payload_plaintext_5
         protected = base64url_decode(JWE_Protected_Header_5_1_4)
         rsa_key = jwk.JWK(**RSA_key_5_1_1)
-        e = jwe.JWE(plaintext, protected)
+        e = jwe.JWE(plaintext, protected,
+                    algs=jwe.default_allowed_algs + ['RSA1_5'])
         e.add_recipient(rsa_key)
         enc = e.serialize()
         e.deserialize(enc, rsa_key)


### PR DESCRIPTION
RSA1_5 relies on the PKCS1 v 1.5 padding algorithm.

This algorithm has been shown time and again to be very difficult to
implement correctly because it requires a fully constant time
implementation including in application level error handling.

Python Cryptography which is our crypto engine documents that the
current API is not contacnt time.

This patch deprecates the algorithm and removes it from the default
allowed algorithms list. This means that code need to be changed in
order to explicitly allow RSA1_5 going forward.

Resolves #193 