### PR TITLE
Make PBES2 behave like all other algorithms

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -583,10 +583,15 @@ class _Pbes2HsAesKw(_RawKeyMgmt):
         self.aeskwmap = {128: _A128KW, 192: _A192KW, 256: _A256KW}
 
     def _get_key(self, alg, key, p2s, p2c):
-        if isinstance(key, bytes):
-            plain = key
+        if not isinstance(key, JWK):
+            # backwards compatiblity for old interface
+            if isinstance(key, bytes):
+                plain = key
+            else:
+                plain = key.encode('utf8')
         else:
-            plain = key.encode('utf8')
+            plain = base64url_decode(key.get_op_key())
+
         salt = bytes(self.name.encode('utf8')) + b'\x00' + p2s
 
         if self.hashsize == 256:

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -1052,6 +1052,21 @@ class JWK(dict):
         except KeyError:
             raise AttributeError
 
+    @classmethod
+    def from_password(cls, password):
+        """Creates a symmetric JWK key from a user password.
+
+        :param key: A password in utf8 format.
+        """
+        obj = cls()
+        params = {'kty': 'oct'}
+        try:
+            params['k'] = base64url_encode(password.encode('utf8'))
+        except Exception as e:  # pylint: disable=broad-except
+            raise InvalidJWKValue(e)
+        obj.import_key(**params)
+        return obj
+
 
 class _JWKkeys(set):
 


### PR DESCRIPTION
PBES2 accepts only a plaintext password or bytes which is different
from all other algorithms. Make it support passing in a symmetric key,
and add a jwk classmethod to create a symmetric key from a password.

Resolves #196 