### PR TITLE
leeway fix

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -330,12 +330,12 @@ class JWT(object):
                 "Claim %s is not an integer" % (name, ))
 
     def _check_exp(self, claim, limit, leeway):
-        if claim < limit - leeway:
+        if claim < limit + leeway:
             raise JWTExpired('Expired at %d, time: %d(leeway: %d)' % (
                              claim, limit, leeway))
 
     def _check_nbf(self, claim, limit, leeway):
-        if claim > limit + leeway:
+        if claim > limit - leeway:
             raise JWTNotYetValid('Valid from %d, time: %d(leeway: %d)' % (
                                  claim, limit, leeway))
 


### PR DESCRIPTION
Leeway is subtracted from the expiration limit, thus giving less time instead of more (similar with _check_nbf()).
Correct me if I'm wrong, but this does not seem to be the intended behaviour.