### PR TITLE
Added six as a dependency to avoid import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
     install_requires = [
         'cryptography >= 2.3',
         'deprecated',
+        'six',
     ],
 )


### PR DESCRIPTION
Six is used as a direct import here: https://github.com/latchset/jwcrypto/blob/master/jwcrypto/jwt.py#L6
But it was not listed as a dependency in the setup.py. Because six is also a dependency of tox the tests didn't fail. When jwcrypto is used as a dependency the system does fails though.

This previously went unnoticed probably because cryptography also had six as a dependency.