### PR TITLE
Drops six dependency.

### DIFF
--- a/jwcrypto/compat.py
+++ b/jwcrypto/compat.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 JWCrypto Project Contributors - see LICENSE file
+
+from __future__ import absolute_import
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+if PY3:
+    string_types = (str, )
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+else:
+    string_types = (basestring, )  # noqa: F821
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper

--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -17,8 +17,6 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
 from cryptography.hazmat.primitives.padding import PKCS7
 
-import six
-
 from jwcrypto.common import InvalidCEKeyLength
 from jwcrypto.common import InvalidJWAAlgorithm
 from jwcrypto.common import InvalidJWEKeyLength
@@ -26,12 +24,13 @@ from jwcrypto.common import InvalidJWEKeyType
 from jwcrypto.common import InvalidJWEOperation
 from jwcrypto.common import base64url_decode, base64url_encode
 from jwcrypto.common import json_decode
+from jwcrypto.compat import add_metaclass
 from jwcrypto.jwk import JWK
 
 # Implements RFC 7518 - JSON Web Algorithms (JWA)
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class JWAAlgorithm(object):
 
     @abc.abstractproperty

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -13,11 +13,10 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 from deprecated import deprecated
 
-from six import iteritems
-
 from jwcrypto.common import JWException
 from jwcrypto.common import base64url_decode, base64url_encode
 from jwcrypto.common import json_decode, json_encode
+from jwcrypto.compat import iteritems
 
 
 class UnimplementedOKPCurveKey(object):

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -3,9 +3,8 @@
 import time
 import uuid
 
-from six import string_types
-
 from jwcrypto.common import JWException, json_decode, json_encode
+from jwcrypto.compat import string_types
 from jwcrypto.jwe import JWE
 from jwcrypto.jwk import JWK, JWKSet
 from jwcrypto.jws import JWS

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,5 @@ setup(
     install_requires = [
         'cryptography >= 2.3',
         'deprecated',
-        'six',
     ],
 )


### PR DESCRIPTION
Following the conversation from #206 , this is a possible step forward to remove six before dropping Python 2.7 support.