### PR TITLE
Set python requirement to 3.6+ in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,5 @@ setup(
         'cryptography >= 2.3',
         'deprecated',
     ],
+    python_requires = '>= 3.6',
 )


### PR DESCRIPTION
This should fix #228 

See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires