### PR TITLE
Use list/dict literals instead

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -82,7 +82,7 @@ def _decode_int(n):
     return int(hexlify(n), 16)
 
 
-class _RawJWS(object):
+class _RawJWS:
 
     def sign(self, key, payload):
         raise NotImplementedError
@@ -333,7 +333,7 @@ class _None(_RawNone, JWAAlgorithm):
     algorithm_use = 'sig'
 
 
-class _RawKeyMgmt(object):
+class _RawKeyMgmt:
 
     def wrap(self, key, bitsize, cek, headers):
         raise NotImplementedError
@@ -849,7 +849,7 @@ class _EdDsa(_RawJWS, JWAAlgorithm):
         raise NotImplementedError
 
 
-class _RawJWE(object):
+class _RawJWE:
 
     def encrypt(self, k, a, m):
         raise NotImplementedError
@@ -1042,7 +1042,7 @@ class _A256Gcm(_AesGcm, JWAAlgorithm):
     algorithm_use = 'enc'
 
 
-class JWA(object):
+class JWA:
     """JWA Signing Algorithms.
 
     This class provides access to all JWA algorithms.

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -70,7 +70,7 @@ InvalidJWEKeyType = common.InvalidJWEKeyType
 InvalidJWEOperation = common.InvalidJWEOperation
 
 
-class JWE(object):
+class JWE:
     """JSON Web Encryption object
 
     This object represent a JWE token.

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -91,7 +91,7 @@ class JWE(object):
         :param header_registry: Optional additions to the header registry
         """
         self._allowed_algs = None
-        self.objects = dict()
+        self.objects = {}
         self.plaintext = None
         self.header_registry = JWSEHeaderRegistry(JWEHeaderRegistry)
         if header_registry:
@@ -164,7 +164,7 @@ class JWE(object):
         return h1
 
     def _get_jose_header(self, header=None):
-        jh = dict()
+        jh = {}
         if 'protected' in self.objects:
             ph = json_decode(self.objects['protected'])
             jh = self._merge_headers(jh, ph)
@@ -229,7 +229,7 @@ class JWE(object):
         jh = self._get_jose_header(header)
         alg, enc = self._get_alg_enc_from_headers(jh)
 
-        rec = dict()
+        rec = {}
         if header:
             rec['header'] = header
 
@@ -250,8 +250,8 @@ class JWE(object):
         if 'recipients' in self.objects:
             self.objects['recipients'].append(rec)
         elif 'encrypted_key' in self.objects or 'header' in self.objects:
-            self.objects['recipients'] = list()
-            n = dict()
+            self.objects['recipients'] = []
+            n = {}
             if 'encrypted_key' in self.objects:
                 n['encrypted_key'] = self.objects.pop('encrypted_key')
             if 'header' in self.objects:
@@ -329,9 +329,9 @@ class JWE(object):
             if 'aad' in obj:
                 enc['aad'] = base64url_encode(obj['aad'])
             if 'recipients' in obj:
-                enc['recipients'] = list()
+                enc['recipients'] = []
                 for rec in obj['recipients']:
-                    e = dict()
+                    e = {}
                     if 'encrypted_key' in rec:
                         e['encrypted_key'] = \
                             base64url_encode(rec['encrypted_key'])
@@ -361,7 +361,7 @@ class JWE(object):
         jh = self._get_jose_header(ppe.get('header', None))
 
         # TODO: allow caller to specify list of headers it understands
-        self._check_crit(jh.get('crit', dict()))
+        self._check_crit(jh.get('crit', {}))
 
         for hdr in jh:
             if hdr in self.header_registry:
@@ -407,7 +407,7 @@ class JWE(object):
 
         if 'ciphertext' not in self.objects:
             raise InvalidJWEOperation("No available ciphertext")
-        self.decryptlog = list()
+        self.decryptlog = []
 
         if 'recipients' in self.objects:
             for rec in self.objects['recipients']:
@@ -442,11 +442,11 @@ class JWE(object):
         :raises InvalidJWEOperation: if the decryption fails.
         """
 
-        self.objects = dict()
+        self.objects = {}
         self.plaintext = None
         self.cek = None
 
-        o = dict()
+        o = {}
         try:
             try:
                 djwe = json_decode(raw_jwe)
@@ -461,9 +461,9 @@ class JWE(object):
                 if 'aad' in djwe:
                     o['aad'] = base64url_decode(djwe['aad'])
                 if 'recipients' in djwe:
-                    o['recipients'] = list()
+                    o['recipients'] = []
                     for rec in djwe['recipients']:
-                        e = dict()
+                        e = {}
                         if 'encrypted_key' in rec:
                             e['encrypted_key'] = \
                                 base64url_decode(rec['encrypted_key'])

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -243,7 +243,7 @@ class InvalidJWKOperation(JWException):
             op = JWKOperationsRegistry[self.op]
         else:
             op = 'Unknown(%s)' % self.op
-        valid = list()
+        valid = []
         for v in self.values:
             if v in list(JWKOperationsRegistry.keys()):
                 valid.append(JWKOperationsRegistry[v])
@@ -483,7 +483,7 @@ class JWK(dict):
         self.import_key(**params)
 
     def import_key(self, **kwargs):
-        newkey = dict()
+        newkey = {}
         key_vals = 0
 
         names = list(kwargs.keys())
@@ -624,7 +624,7 @@ class JWK(dict):
         return pub
 
     def _export_all(self, as_dict=False):
-        d = dict()
+        d = {}
         d.update(self)
         if as_dict is True:
             return d
@@ -1082,7 +1082,7 @@ class JWK(dict):
 
     # Prevent accidental disclosure of key material via repr()
     def __repr__(self):
-        repr_dict = dict()
+        repr_dict = {}
         repr_dict['kid'] = self.get('kid', 'Missing Key ID')
         repr_dict['thumbprint'] = self.thumbprint()
         return json_encode(repr_dict)
@@ -1147,10 +1147,10 @@ class JWKSet(dict):
         :param as_dict(bool): Whether to return a dict instead of
                               a JSON object
         """
-        exp_dict = dict()
+        exp_dict = {}
         for k, v in self.items():
             if k == 'keys':
-                keys = list()
+                keys = []
                 for jwk in v:
                     keys.append(jwk.export(private_keys, as_dict=True))
                 v = keys
@@ -1199,10 +1199,10 @@ class JWKSet(dict):
         return None
 
     def __repr__(self):
-        repr_dict = dict()
+        repr_dict = {}
         for k, v in self.items():
             if k == 'keys':
-                keys = list()
+                keys = []
                 for jwk in v:
                     keys.append(repr(jwk))
                 v = keys

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -18,7 +18,7 @@ from jwcrypto.common import base64url_decode, base64url_encode
 from jwcrypto.common import json_decode, json_encode
 
 
-class UnimplementedOKPCurveKey(object):
+class UnimplementedOKPCurveKey:
     @classmethod
     def generate(cls):
         raise NotImplementedError

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -124,7 +124,7 @@ class JWSCore(object):
 
             self.protected = base64url_encode(header.encode('utf-8'))
         else:
-            self.header = dict()
+            self.header = {}
             self.protected = ''
         self.payload = payload
 
@@ -179,7 +179,7 @@ class JWS(object):
         :param payload(bytes): An arbitrary value (optional).
         :param header_registry: Optional additions to the header registry
         """
-        self.objects = dict()
+        self.objects = {}
         self.objects['payload'] = payload
         self.verifylog = None
         self._allowed_algs = None
@@ -236,7 +236,7 @@ class JWS(object):
             if hn is None:
                 continue
             if header is None:
-                header = dict()
+                header = {}
             for h in list(hn.keys()):
                 if h in self.header_registry:
                     if self.header_registry[h].mustprotect:
@@ -253,7 +253,7 @@ class JWS(object):
 
     # TODO: support selecting key with 'kid' and passing in multiple keys
     def _verify(self, alg, key, payload, signature, protected, header=None):
-        p = dict()
+        p = {}
         # verify it is a valid JSON object and decode
         if protected is not None:
             p = json_decode(protected)
@@ -298,7 +298,7 @@ class JWS(object):
         :raises InvalidJWSSignature: if the verification fails.
         """
 
-        self.verifylog = list()
+        self.verifylog = []
         self.objects['valid'] = False
         obj = self.objects
         if 'signature' in obj:
@@ -332,8 +332,7 @@ class JWS(object):
                                       'signatures' + repr(self.verifylog))
 
     def _deserialize_signature(self, s):
-        o = dict()
-        o['signature'] = base64url_decode(str(s['signature']))
+        o = {'signature': base64url_decode(str(s['signature']))}
         if 'protected' in s:
             p = base64url_decode(str(s['protected']))
             o['protected'] = p.decode('utf-8')
@@ -375,13 +374,13 @@ class JWS(object):
         :raises InvalidJWSObject: if the raw object is an invalid JWS token.
         :raises InvalidJWSSignature: if the verification fails.
         """
-        self.objects = dict()
-        o = dict()
+        self.objects = {}
+        o = {}
         try:
             try:
                 djws = json_decode(raw_jws)
                 if 'signatures' in djws:
-                    o['signatures'] = list()
+                    o['signatures'] = []
                     for s in djws['signatures']:
                         os = self._deserialize_signature(s)
                         o['signatures'].append(os)
@@ -437,7 +436,7 @@ class JWS(object):
 
         b64 = True
 
-        p = dict()
+        p = {}
         if protected:
             if isinstance(protected, dict):
                 p = protected
@@ -482,20 +481,20 @@ class JWS(object):
         )
         sig = c.sign()
 
-        o = dict()
-        o['signature'] = base64url_decode(sig['signature'])
+        o = {
+            'signature': base64url_decode(sig['signature']),
+            'valid': True,
+        }
         if protected:
             o['protected'] = protected
         if header:
             o['header'] = h
-        o['valid'] = True
 
         if 'signatures' in self.objects:
             self.objects['signatures'].append(o)
         elif 'signature' in self.objects:
-            self.objects['signatures'] = list()
-            n = dict()
-            n['signature'] = self.objects.pop('signature')
+            self.objects['signatures'] = []
+            n = {'signature': self.objects.pop('signature')}
             if 'protected' in self.objects:
                 n['protected'] = self.objects.pop('protected')
             if 'header' in self.objects:
@@ -554,7 +553,7 @@ class JWS(object):
                              base64url_encode(self.objects['signature'])])
         else:
             obj = self.objects
-            sig = dict()
+            sig = {}
             payload = self.objects.get('payload', '')
             if self.objects.get('b64', True):
                 sig['payload'] = base64url_encode(payload)
@@ -569,7 +568,7 @@ class JWS(object):
                 if 'header' in obj:
                     sig['header'] = obj['header']
             elif 'signatures' in obj:
-                sig['signatures'] = list()
+                sig['signatures'] = []
                 for o in obj['signatures']:
                     if not o.get('valid', False):
                         continue
@@ -602,16 +601,16 @@ class JWS(object):
                 p = json_decode(obj['protected'])
             else:
                 p = None
-            return self._merge_check_headers(p, obj.get('header', dict()))
+            return self._merge_check_headers(p, obj.get('header', {}))
         elif 'signatures' in self.objects:
-            jhl = list()
+            jhl = []
             for o in obj['signatures']:
-                jh = dict()
+                jh = {}
                 if 'protected' in o:
                     p = json_decode(o['protected'])
                 else:
                     p = None
-                jh = self._merge_check_headers(p, o.get('header', dict()))
+                jh = self._merge_check_headers(p, o.get('header', {}))
                 jhl.append(jh)
             return jhl
         else:

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -85,7 +85,7 @@ class InvalidJWSOperation(JWException):
         super(InvalidJWSOperation, self).__init__(msg)
 
 
-class JWSCore(object):
+class JWSCore:
     """The inner JWS Core object.
 
     This object SHOULD NOT be used directly, the JWS object should be
@@ -167,7 +167,7 @@ class JWSCore(object):
         return True
 
 
-class JWS(object):
+class JWS:
     """JSON Web Signature object
 
     This object represent a JWS token.

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -484,7 +484,7 @@ class JWT(object):
         if self._algs:
             self.token.allowed_algs = self._algs
 
-        self.deserializelog = list()
+        self.deserializelog = []
         # now deserialize and also decrypt/verify (or raise) if we
         # have a key
         if key is None:

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -143,7 +143,7 @@ class JWTMissingKey(JWException):
         super(JWTMissingKey, self).__init__(msg)
 
 
-class JWT(object):
+class JWT:
     """JSON Web token object
 
     This object represent a generic token.

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -392,7 +392,7 @@ class TestJWK(unittest.TestCase):
         self.assertEqual(kec1.get_op_key('verify').public_numbers().x,
                          kec2.get_op_key('verify').public_numbers().x)
         self.assertRaises(jwk.InvalidJWKValue,
-                          jwk.JWK.from_pyca, dict())
+                          jwk.JWK.from_pyca, {})
 
     def test_jwk_from_json(self):
         k = jwk.JWK.generate(kty='oct', size=256)


### PR DESCRIPTION
I'm not sure if the object-commit really adds any value. You can delete it, if desired. There's no speed difference, unlike the `{}` and `[]` replacements.  