### PR TITLE
Fix key_op in get_op_key for RSA unwrap operation

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -364,7 +364,7 @@ class _RSA(_RawKeyMgmt):
 
     def unwrap(self, key, bitsize, ek, headers):
         self._check_key(key)
-        rk = key.get_op_key('decrypt')
+        rk = key.get_op_key('unwrapKey')
         cek = rk.decrypt(ek, self.padfn)
         if _bitsize(cek) != bitsize:
             raise InvalidJWEKeyLength(bitsize, _bitsize(cek))


### PR DESCRIPTION
JWE does not define any algorithm to asymmetrically encrypt content
direcly. Instead, algorithms like RSA-OAEP-256 wrap an AES key which is
then used to symmetrically encrypt the content.

This fixes a bug where JWE decryption fails with JWKs with `key_ops: ["unwrapKey"]`. 

Section 4.3 of RFC 7517 defines the `unwrapKey` operation as "decrypt
key and validate decryption, if applicable" which is exactly what RSA
keys are used for in algorithms like RSA-OAEP-256.

see https://datatracker.ietf.org/doc/html/rfc7517#section-4.3