### PR TITLE
Add a sphinx doctest target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@
                         "python-39",
                         "python-310",
                         "doc",
+                        "doctest",
                         "sphinx",
                         "lint",
                         "pep8",
@@ -59,6 +60,12 @@
                             "name": "doc",
                             "python": "3.10",
                             "toxenv": "doc",
+                            "arch": "x64",
+                        },
+                        {
+                            "name": "doctest",
+                            "python": "3.10",
+                            "toxenv": "doctest",
                             "arch": "x64",
                         },
                         {

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ DOCS_DIR = docs
 .PHONY: docs
 
 docs:
-	$(MAKE) -C $(DOCS_DIR) html
+	$(MAKE) -C $(DOCS_DIR) html doctest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,11 @@ sys.path.insert(0, os.path.abspath('../..'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.doctest',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,10 @@ Contents:
    jwt
 
 
+Note: In the examples, random or generated output values are replaced
+with '...' to allow for doctesting. Where possible the immutable part of
+a token has been preserved, and only the variable part replaced with '...'
+
 Indices and tables
 ==================
 

--- a/docs/source/jwe.rst
+++ b/docs/source/jwe.rst
@@ -60,8 +60,8 @@ Encrypt a JWE token::
     >>> key = jwk.JWK.generate(kty='oct', size=256)
     >>> payload = "My Encrypted message"
     >>> jwetoken = jwe.JWE(payload.encode('utf-8'),
-                           json_encode({"alg": "A256KW",
-                                        "enc": "A256CBC-HS512"}))
+    ...                    json_encode({"alg": "A256KW",
+    ...                                 "enc": "A256CBC-HS512"}))
     >>> jwetoken.add_recipient(key)
     >>> enc = jwetoken.serialize()
 
@@ -82,14 +82,14 @@ Encrypt a JWE token::
     >>> public_key.import_key(**json_decode(private_key.export_public()))
     >>> payload = "My Encrypted message"
     >>> protected_header = {
-            "alg": "RSA-OAEP-256",
-            "enc": "A256CBC-HS512",
-            "typ": "JWE",
-            "kid": public_key.thumbprint(),
-        }
+    ...     "alg": "RSA-OAEP-256",
+    ...     "enc": "A256CBC-HS512",
+    ...     "typ": "JWE",
+    ...     "kid": public_key.thumbprint(),
+    ... }
     >>> jwetoken = jwe.JWE(payload.encode('utf-8'),
-                           recipient=public_key,
-                           protected=protected_header)
+    ...                    recipient=public_key,
+    ...                    protected=protected_header)
     >>> enc = jwetoken.serialize()
 
 Decrypt a JWE token::

--- a/docs/source/jwk.rst
+++ b/docs/source/jwk.rst
@@ -66,25 +66,24 @@ Create a 256bit symmetric key::
     >>> key = jwk.JWK.generate(kty='oct', size=256)
 
 Export the key with::
-    >>> key.export()
-    '{"k":"X6TBlwY2so8EwKZ2TFXM7XHSgWBKQJhcspzYydp5Y-o","kty":"oct"}'
+    >>> key.export()    #doctest: +ELLIPSIS
+    '{"k":"...","kty":"oct"}'
 
 Create a 2048bit RSA key pair::
-    >>> jwk.JWK.generate(kty='RSA', size=2048)
+    >>> jwk.JWK.generate(kty='RSA', size=2048) #doctest: +ELLIPSIS
+    {"kid":"Missing Key ID","thumbprint":"..."}
 
 Create a P-256 EC key pair and export the public key::
     >>> key = jwk.JWK.generate(kty='EC', crv='P-256')
-    >>> key.export(private_key=False)
-    '{"y":"VYlYwBfOTIICojCPfdUjnmkpN-g-lzZKxzjAoFmDRm8",
-      "x":"3mdE0rODWRju6qqU01Kw5oPYdNxBOMisFvJFH1vEu9Q",
-      "crv":"P-256","kty":"EC"}'
+    >>> key.export(private_key=False)   #doctest: +ELLIPSIS
+    '{"crv":"P-256","kty":"EC","x":"...","y":"..."}'
 
 Import a P-256 Public Key::
     >>> expkey = {"y":"VYlYwBfOTIICojCPfdUjnmkpN-g-lzZKxzjAoFmDRm8",
-                  "x":"3mdE0rODWRju6qqU01Kw5oPYdNxBOMisFvJFH1vEu9Q",
-                  "crv":"P-256","kty":"EC"}
+    ...           "x":"3mdE0rODWRju6qqU01Kw5oPYdNxBOMisFvJFH1vEu9Q",
+    ...           "crv":"P-256","kty":"EC"}
     >>> key = jwk.JWK(**expkey)
 
 Import a Key from a PEM file::
-    >>> with open("public.pem", "rb") as pemfile:
-    >>>     key = jwk.JWK.from_pem(pemfile.read())
+    >>> with open("public.pem", "rb") as pemfile:  #doctest: +SKIP
+    ...     key = jwk.JWK.from_pem(pemfile.read())

--- a/docs/source/jws.rst
+++ b/docs/source/jws.rst
@@ -54,8 +54,8 @@ Sign a JWS token::
     >>> payload = "My Integrity protected message"
     >>> jwstoken = jws.JWS(payload.encode('utf-8'))
     >>> jwstoken.add_signature(key, None,
-                               json_encode({"alg": "HS256"}),
-                               json_encode({"kid": key.thumbprint()}))
+    ...                        json_encode({"alg": "HS256"}),
+    ...                        json_encode({"kid": key.thumbprint()}))
     >>> sig = jwstoken.serialize()
 
 Verify a JWS token::

--- a/docs/source/jwt.rst
+++ b/docs/source/jwt.rst
@@ -20,29 +20,29 @@ Examples
 Create a symmetric key::
     >>> from jwcrypto import jwt, jwk
     >>> key = jwk.JWK(generate='oct', size=256)
-    >>> key.export()
-    '{"k":"Wal4ZHCBsml0Al_Y8faoNTKsXCkw8eefKXYFuwTBOpA","kty":"oct"}'
+    >>> key.export()  # doctest: +ELLIPSIS
+    '{"k":"...","kty":"oct"}'
 
 Create a signed token with the generated key::
     >>> Token = jwt.JWT(header={"alg": "HS256"},
-                        claims={"info": "I'm a signed token"})
+    ...                 claims={"info": "I'm a signed token"})
     >>> Token.make_signed_token(key)
-    >>> Token.serialize()
-    u'eyJhbGciOiJIUzI1NiJ9.eyJpbmZvIjoiSSdtIGEgc2lnbmVkIHRva2VuIn0.rjnRMAKcaRamEHnENhg0_Fqv7Obo-30U4bcI_v-nfEM'
+    >>> Token.serialize()       #doctest: +ELLIPSIS
+    'eyJhbGciOiJIUzI1NiJ9.eyJpbmZvIjoiSSdtIGEgc2lnbmVkIHRva2VuIn0...'
 
 Further encrypt the token with the same key::
     >>> Etoken = jwt.JWT(header={"alg": "A256KW", "enc": "A256CBC-HS512"},
-                         claims=Token.serialize())
+    ...                  claims=Token.serialize())
     >>> Etoken.make_encrypted_token(key)
     >>> Etoken.serialize()
-    u'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0.ST5RmjqDLj696xo7YFTFuKUhcd3naCrm6yMjBM3cqWiFD6U8j2JIsbclsF7ryNg8Ktmt1kQJRKavV6DaTl1T840tP3sIs1qz.wSxVhZH5GyzbJnPBAUMdzQ.6uiVYwrRBzAm7Uge9rEUjExPWGbgerF177A7tMuQurJAqBhgk3_5vee5DRH84kHSapFOxcEuDdMBEQLI7V2E0F57-d01TFStHzwtgtSmeZRQ6JSIL5XlgJouwHfSxn9Z_TGl5xxq4TksORHED1vnRA.5jPyPWanJVqlOohApEbHmxi3JHp1MXbmvQe2_dVd8FI'
+    'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0...'
 
 Now decrypt and verify::
     >>> from jwcrypto import jwt, jwk
     >>> k = {"k": "Wal4ZHCBsml0Al_Y8faoNTKsXCkw8eefKXYFuwTBOpA", "kty": "oct"}
     >>> key = jwk.JWK(**k)
-    >>> e = u'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0.ST5RmjqDLj696xo7YFTFuKUhcd3naCrm6yMjBM3cqWiFD6U8j2JIsbclsF7ryNg8Ktmt1kQJRKavV6DaTl1T840tP3sIs1qz.wSxVhZH5GyzbJnPBAUMdzQ.6uiVYwrRBzAm7Uge9rEUjExPWGbgerF177A7tMuQurJAqBhgk3_5vee5DRH84kHSapFOxcEuDdMBEQLI7V2E0F57-d01TFStHzwtgtSmeZRQ6JSIL5XlgJouwHfSxn9Z_TGl5xxq4TksORHED1vnRA.5jPyPWanJVqlOohApEbHmxi3JHp1MXbmvQe2_dVd8FI'
+    >>> e = 'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0.ST5RmjqDLj696xo7YFTFuKUhcd3naCrm6yMjBM3cqWiFD6U8j2JIsbclsF7ryNg8Ktmt1kQJRKavV6DaTl1T840tP3sIs1qz.wSxVhZH5GyzbJnPBAUMdzQ.6uiVYwrRBzAm7Uge9rEUjExPWGbgerF177A7tMuQurJAqBhgk3_5vee5DRH84kHSapFOxcEuDdMBEQLI7V2E0F57-d01TFStHzwtgtSmeZRQ6JSIL5XlgJouwHfSxn9Z_TGl5xxq4TksORHED1vnRA.5jPyPWanJVqlOohApEbHmxi3JHp1MXbmvQe2_dVd8FI'
     >>> ET = jwt.JWT(key=key, jwt=e)
     >>> ST = jwt.JWT(key=key, jwt=ET.claims)
     >>> ST.claims
-    u'{"info":"I\'m a signed token"}'
+    '{"info":"I\'m a signed token"}'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py36,py37,py38,py39,py310,pep8,doc,sphinx
+envlist = lint,py36,py37,py38,py39,py310,pep8,doc,sphinx,doctest
 skip_missing_interpreters = true
 
 [testenv]
@@ -48,6 +48,14 @@ deps =
     sphinx
 commands =
     sphinx-build -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[testenv:doctest]
+basepython = python3.10
+changedir = docs/source
+deps =
+    sphinx
+commands =
+    sphinx-build -v -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/doctest
 
 [pytest]
 python_files = jwcrypto/test*.py


### PR DESCRIPTION
Reformat example code as necessary to make it pass tests.
Specifically some of the randomly generated output has been replaced
with '...' which is the only way to make doctest match/skip a part of
the ouput while still running the command for testing.

Resolves #102 