### PR TITLE
handle keys with duplicate kids

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -1139,7 +1139,7 @@ class JWK(dict):
     def from_password(cls, password):
         """Creates a symmetric JWK key from a user password.
 
-        :param key: A password in utf8 format.
+        :param password: A password in utf8 format.
         """
         obj = cls()
         params = {'kty': 'oct'}
@@ -1263,10 +1263,20 @@ class JWKSet(dict):
         """Gets a key from the set.
         :param kid: the 'kid' key identifier.
         """
-        for jwk in self['keys']:
-            if jwk.get('kid') == kid:
-                return jwk
-        return None
+        keys = self.get_keys(kid)
+        if len(keys) > 1:
+            raise InvalidJWKValue(
+                'Duplicate keys found with requested kid: 1 expected')
+        try:
+            return tuple(keys)[0]
+        except IndexError:
+            return None
+
+    def get_keys(self, kid):
+        """Gets keys from the set with matching kid.
+        :param kid: the 'kid' key identifier.
+        """
+        return {key for key in self['keys'] if key.get('kid') == kid}
 
     def __repr__(self):
         repr_dict = {}


### PR DESCRIPTION
Well, crud. I accidentally close #266 it seems. Here is the description, for reference.

I recently ran into a case where token servers had unique keys but with duplicate `kid`s. Looking at the RFC, it has pretty loose requirements for `kid` and doesn't even require that `kid` be unique:

>[4.5](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5).  "kid" (Key ID) Parameter
> 
>    The "kid" (key ID) parameter is used to match a specific key.  This is used, for instance, to choose among a set of keys within a JWK Set during key rollover.  The structure of the "kid" value is unspecified.  When "kid" values are used within a JWK Set, different keys within the JWK Set SHOULD use distinct "kid" values.  (One example in which different keys might use the same "kid" value is if they have different "kty" (key type) values but are considered to be equivalent alternatives by the application using them.)  The "kid" value is a case-sensitive string.  Use of this member is OPTIONAL. When used with JWS or JWE, the "kid" value is used to match a JWS or JWE "kid" Header Parameter value.

I think, the way the JKWSet is written now, it would not properly handle the example case, since it may find the different `kty` key and fail there, rather than moving on to the key with the correct `kty`. So, rather than assume that the first key with a matching `kid` is the only correct key, better to try each key with a matching kid.