### PR TITLE
Source README.md in setup to be used for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@
 
 from setuptools import setup
 
+# read the contents of your README file
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(
     name = 'jwcrypto',
     version = '1.2',
@@ -13,6 +18,8 @@ setup(
     url='https://github.com/latchset/jwcrypto',
     packages = ['jwcrypto'],
     description = 'Implementation of JOSE Web standards',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     classifiers = [
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
When Release scripts publish to PyPI they will set the README.md as
the long decription there.