### PR TITLE
Allow passing p2s/p2c params on encrypting

### DIFF
--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -280,7 +280,7 @@ class JWE:
             for invalid in 'aad', 'unprotected':
                 if invalid in self.objects:
                     raise InvalidJWEOperation(
-                        "Can't use compact encoding when the '%s' parameter"
+                        "Can't use compact encoding when the '%s' parameter "
                         "is set" % invalid)
             if 'protected' not in self.objects:
                 raise InvalidJWEOperation(

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1788,6 +1788,28 @@ class ConformanceTests(unittest.TestCase):
         check.decrypt(key)
         self.assertEqual(check.payload, b'plain')
 
+    def test_pbes2_hs256_aeskw_custom_params(self):
+        enc = jwe.JWE(plaintext='plain',
+                      protected={"alg": "PBES2-HS256+A128KW",
+                                 "enc": "A256CBC-HS512",
+                                 "p2c": 4096,
+                                 "p2s": base64url_encode("A" * 16)})
+        key = jwk.JWK.from_password('password')
+        enc.add_recipient(key)
+        o = enc.serialize()
+        check = jwe.JWE()
+        check.deserialize(o)
+        check.decrypt(key)
+        self.assertEqual(check.payload, b'plain')
+
+        enc = jwe.JWE(plaintext='plain',
+                      protected={"alg": "PBES2-HS256+A128KW",
+                                 "enc": "A256CBC-HS512",
+                                 "p2c": 4096,
+                                 "p2s": base64url_encode("A" * 7)})
+        key = jwk.JWK.from_password('password')
+        self.assertRaises(ValueError, enc.add_recipient, key)
+
 
 class JWATests(unittest.TestCase):
     def test_jwa_create(self):


### PR DESCRIPTION
This was not really obvious but clearly it should be possible to pass in
parameters (p2s/p2c) in input when using PBES, and set defaults if they
are not provided.

Fixes #279 