### PR TITLE
Immutable args

### DIFF
--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -118,10 +118,9 @@ class JWSCore:
 
         if header is not None:
             if isinstance(header, dict):
-                self.header = header
                 header = json_encode(header)
-            else:
-                self.header = json_decode(header)
+            # Make sure this is always a deep copy of the dict
+            self.header = json_decode(header)
 
             self.protected = base64url_encode(header.encode('utf-8'))
         else:
@@ -454,13 +453,13 @@ class JWS:
 
         b64 = True
 
-        p = {}
         if protected:
             if isinstance(protected, dict):
-                p = protected
-                protected = json_encode(p)
-            else:
-                p = json_decode(protected)
+                protected = json_encode(protected)
+            # Make sure p is always a deep copy of the dict
+            p = json_decode(protected)
+        else:
+            p = dict()
 
         # If b64 is present we must enforce criticality
         if 'b64' in list(p.keys()):
@@ -476,10 +475,9 @@ class JWS:
         h = None
         if header:
             if isinstance(header, dict):
-                h = header
                 header = json_encode(header)
-            else:
-                h = json_decode(header)
+            # Make sure h is always a deep copy of the dict
+            h = json_decode(header)
 
         p = self._merge_check_headers(p, h)
 

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2015  JWCrypto Project Contributors - see LICENSE file
 
+import copy
 import time
 import uuid
 
@@ -232,15 +233,19 @@ class JWT:
 
     @claims.setter
     def claims(self, c):
-        if self._reg_claims and not isinstance(c, dict):
-            # decode c so we can set default claims
+        if not isinstance(c, dict):
+            if not self._reg_claims:
+                # no default_claims, can return immediately
+                self._claims = c
+                return
             c = json_decode(c)
-
-        if isinstance(c, dict):
-            self._add_default_claims(c)
-            self._claims = json_encode(c)
         else:
-            self._claims = c
+            # _add_default_claims modifies its argument
+            # so we must always copy it.
+            c = copy.deepcopy(c)
+
+        self._add_default_claims(c)
+        self._claims = json_encode(c)
 
     @property
     def token(self):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -995,6 +995,18 @@ class TestJWS(unittest.TestCase):
         t.deserialize(o1)
         t.verify(key)
 
+    def test_jws_issue_281(self):
+        header = {"alg": "HS256"}
+        header_copy = copy.deepcopy(header)
+
+        key = jwk.JWK().generate(kty='oct')
+
+        s = jws.JWS(payload='test')
+        s.add_signature(key, protected=header,
+                        header={"kid": key.thumbprint()})
+
+        self.assertEqual(header, header_copy)
+
 
 E_A1_plaintext = \
     [84, 104, 101, 32, 116, 114, 117, 101, 32, 115, 105, 103, 110, 32,


### PR DESCRIPTION
In some cases (when a dict is passed instead of a json string) some operations would end up referencing the arguments directly and modifying them during processing.

Ensure arguments that may be stored and modified are actually copied in.

Fixes #281