### PR TITLE
Move JWKSet processing from JWT into JWE and JWS directly

### DIFF
--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1500,7 +1500,7 @@ class TestJWT(unittest.TestCase):
         t.make_encrypted_token(key)
         token = t.serialize()
         # try to decrypt without a matching key
-        self.assertRaises(jwt.JWTMissingKey, jwt.JWT, jwt=token, key=keyset,
+        self.assertRaises(Exception, jwt.JWT, jwt=token, key=keyset,
                           algs=jwe_algs_and_rsa1_5,
                           check_claims={'exp': 1300819380})
         # now decrypt with key
@@ -1514,7 +1514,7 @@ class TestJWT(unittest.TestCase):
         t = jwt.JWT(header, A1_claims, algs=jwe_algs_and_rsa1_5)
         t.make_encrypted_token(key)
         token = t.serialize()
-        self.assertRaises(jwt.JWTMissingKey, jwt.JWT, jwt=token, key=keyset)
+        self.assertRaises(Exception, jwt.JWT, jwt=token, key=keyset)
 
         keyset = jwk.JWKSet.from_json(json_encode(PrivateKeys))
         # encrypt a new JWT with no kid
@@ -1523,7 +1523,7 @@ class TestJWT(unittest.TestCase):
         t.make_encrypted_token(key)
         token = t.serialize()
         # try to decrypt without a matching key
-        self.assertRaises(jwt.JWTMissingKey, jwt.JWT, jwt=token, key=keyset,
+        self.assertRaises(Exception, jwt.JWT, jwt=token, key=keyset,
                           algs=jwe_algs_and_rsa1_5,
                           check_claims={'exp': 1300819380})
         # now decrypt with key
@@ -1546,7 +1546,7 @@ class TestJWT(unittest.TestCase):
         token = t.serialize()
 
         # try to decrypt without a matching key
-        with self.assertRaises(jwt.JWTMissingKey):
+        with self.assertRaises(Exception):
             jwt.JWT(jwt=token, key=keyset, algs=jwe_algs_and_rsa1_5,
                     check_claims={'exp': 1300819380})
 


### PR DESCRIPTION
This finally allows to use JWKSets directly with JWE and JWS tokens and reduces the spamming of the decryoptlog/verifylog when a kid is provided in the headers and the keyset has the matching kid for a key.

Fixes #129 