### PR TITLE
Try to disable HW optimizations on ppc64le

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 setenv =
     PYTHONPATH = {envsitepackagesdir}
+    OPENSSL_ppccap = 0x0
 deps =
     pytest
     coverage


### PR DESCRIPTION
As builds started failing with latest Fedora/openssl try to see if it is
due to HW optimizations failing on the github runner.
