### PR TITLE
Introduce a new JWKeyNotFound exception

### DIFF
--- a/docs/source/common.rst
+++ b/docs/source/common.rst
@@ -36,3 +36,6 @@ Exceptions
 
 .. autoclass:: jwcrypto.common.InvalidJWSERegOperation
    :show-inheritance:
+
+.. autoclass:: jwcrypto.common.JWKeyNotFound
+   :show-inheritance:

--- a/jwcrypto/common.py
+++ b/jwcrypto/common.py
@@ -126,6 +126,22 @@ class InvalidJWSERegOperation(JWException):
         super(InvalidJWSERegOperation, self).__init__(msg)
 
 
+class JWKeyNotFound(JWException):
+    """The key needed to complete the operation was not found.
+
+    This exception is raised when a JWKSet is used to perform
+    some operation and the key required to successfully complete
+    the operation is not found.
+    """
+
+    def __init__(self, message=None):
+        if message:
+            msg = message
+        else:
+            msg = 'Key Not Found'
+        super(JWKeyNotFound, self).__init__(msg)
+
+
 # JWSE Header Registry definitions
 
 # RFC 7515 - 9.1: JSON Web Signature and Encryption Header Parameters Registry

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -6,7 +6,8 @@ import uuid
 
 from deprecated import deprecated
 
-from jwcrypto.common import JWException, json_decode, json_encode
+from jwcrypto.common import JWException, JWKeyNotFound
+from jwcrypto.common import json_decode, json_encode
 from jwcrypto.jwe import JWE
 from jwcrypto.jws import JWS
 
@@ -127,8 +128,7 @@ class JWTMissingKeyID(JWException):
         super(JWTMissingKeyID, self).__init__(msg)
 
 
-@deprecated
-class JWTMissingKey(JWException):
+class JWTMissingKey(JWKeyNotFound):
     """JSON Web Token is using a key not in the key set.
 
     This exception is raised if the key that was used is not available
@@ -515,6 +515,8 @@ class JWT:
                 self.deserializelog = self.token.decryptlog
             self.deserializelog.append(
                 'Validation failed: [{}]'.format(repr(e)))
+            if isinstance(e, JWKeyNotFound):
+                raise JWTMissingKey() from e
             raise
 
         self.header = self.token.jose_header


### PR DESCRIPTION
This new Exception is returned only for the newly introduced support for
using JWKset.
This patch also includes a bugfix for jwe to be able to successfully
decrypt using a JWKSet, which was non-functional, and a direct test for
both JWE and JWS to insure no regressions in JWKSet support.

Also restores use of JWTMissingKey for backwards compatibility.

Fixes #291 