### PR TITLE
Add fix for CVE-2022-3102

### DIFF
--- a/docs/source/jwt.rst
+++ b/docs/source/jwt.rst
@@ -14,6 +14,13 @@ Classes
    :members:
    :show-inheritance:
 
+Variables
+---------
+
+.. autodata:: jwcrypto.jwt.JWTClaimsRegistry
+
+.. autodata:: jwcrypto.jwt.JWT_expect_type
+
 Examples
 --------
 

--- a/docs/source/jwt.rst
+++ b/docs/source/jwt.rst
@@ -42,7 +42,7 @@ Now decrypt and verify::
     >>> k = {"k": "Wal4ZHCBsml0Al_Y8faoNTKsXCkw8eefKXYFuwTBOpA", "kty": "oct"}
     >>> key = jwk.JWK(**k)
     >>> e = 'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0.ST5RmjqDLj696xo7YFTFuKUhcd3naCrm6yMjBM3cqWiFD6U8j2JIsbclsF7ryNg8Ktmt1kQJRKavV6DaTl1T840tP3sIs1qz.wSxVhZH5GyzbJnPBAUMdzQ.6uiVYwrRBzAm7Uge9rEUjExPWGbgerF177A7tMuQurJAqBhgk3_5vee5DRH84kHSapFOxcEuDdMBEQLI7V2E0F57-d01TFStHzwtgtSmeZRQ6JSIL5XlgJouwHfSxn9Z_TGl5xxq4TksORHED1vnRA.5jPyPWanJVqlOohApEbHmxi3JHp1MXbmvQe2_dVd8FI'
-    >>> ET = jwt.JWT(key=key, jwt=e)
+    >>> ET = jwt.JWT(key=key, jwt=e, expected_type="JWE")
     >>> ST = jwt.JWT(key=key, jwt=ET.claims)
     >>> ST.claims
     '{"info":"I\'m a signed token"}'

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -22,6 +22,17 @@ JWTClaimsRegistry = {'iss': 'Issuer',
                      'nbf': 'Not Before',
                      'iat': 'Issued At',
                      'jti': 'JWT ID'}
+"""Registry of RFC 7519 defined claims"""
+
+
+# do not use this unless you know about CVE-2022-3102
+JWT_expect_type = True
+"""This module parameter can disable the use of the expectation
+   feature that has been introduced to fix CVE-2022-3102. This knob
+   has been added as a workaround for applications that can't be
+   immediately refactored to deal with the change in behavior but it
+   is considered deprecated and will be removed in a future release.
+"""
 
 
 class JWTExpired(JWException):
@@ -542,11 +553,11 @@ class JWT:
         validate_fn = None
 
         if isinstance(self.token, JWS):
-            if et != "JWS":
+            if et != "JWS" and JWT_expect_type:
                 raise TypeError("Expected {}, got JWS".format(et))
             validate_fn = self.token.verify
         elif isinstance(self.token, JWE):
-            if et != "JWE":
+            if et != "JWE" and JWT_expect_type:
                 print("algs: {}".format(self._algs))
                 raise TypeError("Expected {}, got JWE".format(et))
             validate_fn = self.token.decrypt

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1763,6 +1763,11 @@ class TestJWT(unittest.TestCase):
         token.make_encrypted_token(key)
         enctok = token.serialize()
 
+        # test workaroud for older applications
+        jwt.JWT_expect_type = False
+        jwt.JWT(jwt=enctok, key=key)
+        jwt.JWT_expect_type = True
+
         token.validate(key)
         token.expected_type = "JWE"
         token.validate(key)


### PR DESCRIPTION
Note this fix technically breaks the current JWT api.
unfortunately there was no way to address this weakness without a change in semantics.

This means some applications may throw exceptions in some cases that were previously handled.

A knob to alter this behavior has been provided for applications that can't immediately refactor but still wants a way to upgrade t later jwcrypto releases.