### PR TITLE
Fix typo in new backwards JWT compat heuristics

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -303,7 +303,7 @@ class JWT:
             if set(self._algs).issubset(jwe_algs + ['RSA1_5']):
                 self._expected_type = "JWE"
             elif set(self._algs).issubset(jws_algs):
-                self._expected_type = "JES"
+                self._expected_type = "JWS"
         if self._expected_type is None and self._header:
             if "enc" in json_decode(self._header):
                 self._expected_type = "JWE"

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1758,6 +1758,8 @@ class TestJWT(unittest.TestCase):
         with self.assertRaises(TypeError):
             jwt.JWT(jwt=sertok, key=key, expected_type='JWE')
 
+        jwt.JWT(jwt=sertok, algs=['HS256'], key=key)
+
         key.use = 'sig'
         jwt.JWT(jwt=sertok, key=key)
         key.use = 'enc'
@@ -1798,6 +1800,8 @@ class TestJWT(unittest.TestCase):
             jwt.JWT(jwt=enctok, key=key)
         with self.assertRaises(TypeError):
             jwt.JWT(jwt=enctok, key=key, expected_type='JWS')
+
+        jwt.JWT(jwt=enctok, algs=['A256KW', 'A256GCM'], key=key)
 
         key.use = 'enc'
         jwt.JWT(jwt=enctok, key=key)


### PR DESCRIPTION
I just noticed that the test suite of a package I'm working on are suddenly failing. Short digging later, there was a typo in the newly released 1.4.1
