### PR TITLE
Fix typos with codespell

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -990,7 +990,7 @@ class _AesGcm(_RawJWE):
 
     # RFC 7518 - 5.3
     def encrypt(self, k, a, m):
-        """ Encrypt accoriding to the selected encryption and hashing
+        """ Encrypt according to the selected encryption and hashing
         functions.
 
         :param k: Encryption key (optional)
@@ -1009,7 +1009,7 @@ class _AesGcm(_RawJWE):
         return (iv, e, encryptor.tag)
 
     def decrypt(self, k, a, iv, e, t):
-        """ Decrypt accoriding to the selected encryption and hashing
+        """ Decrypt according to the selected encryption and hashing
         functions.
         :param k: Encryption key (optional)
         :param a: Additional Authenticated Data

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -317,7 +317,7 @@ class JWK(dict):
         valid key type as value then a new key will be generated according
         to the defaults or provided key strength options (type specific).
 
-        :param \**kwargs: parameters (otional).
+        :param \**kwargs: parameters (optional).
 
         :raises InvalidJWKType: if the key type is invalid
         :raises InvalidJWKValue: if incorrect or inconsistent parameters

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -324,7 +324,7 @@ class JWS:
                 return dp
             else:
                 raise InvalidJWSOperation('Object Payload present but'
-                                          ' Deatched Payload provided')
+                                          ' Detached Payload provided')
         return op
 
     def verify(self, key, alg=None, detached_payload=None):

--- a/jwcrypto/tests-cookbook.py
+++ b/jwcrypto/tests-cookbook.py
@@ -1101,7 +1101,7 @@ JWE_flattened_5_12_5 = {
 
 # In general we can't compare ciphertexts with the reference because
 # either the algorithms use random nonces to authenticate the ciphertext
-# or we randomly genrate the nonce when we create the JWe.
+# or we randomly generate the nonce when we create the JWe.
 # To double check implementation we encrypt/decrypt our own input and then
 # decrypt the reference and check it against the given plaintext
 class Cookbook08JWETests(unittest.TestCase):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -428,7 +428,7 @@ class TestJWK(unittest.TestCase):
         ks3 = jwk.JWKSet.from_json(ks.export())
         self.assertEqual(len(ks), len(ks3))
 
-        # Test key set with mutiple keys
+        # Test key set with multiple keys
         ksm = jwk.JWKSet.from_json(json_encode(PrivateKeys))
         num = 0
         for item in ksm:
@@ -438,7 +438,7 @@ class TestJWK(unittest.TestCase):
         self.assertEqual(num, len(PrivateKeys['keys']))
 
     def test_jwkset_get_keys(self):
-        # Test key set with mutiple keys
+        # Test key set with multiple keys
         ksm = jwk.JWKSet.from_json(json_encode(PrivateKeys))
         k1 = jwk.JWK.from_json(json_encode(PrivateKeys['keys'][0]))
         kwargs = RSAPrivateKey.copy()
@@ -881,7 +881,7 @@ class TestJWS(unittest.TestCase):
             self.assertEqual(decsig, test['signature'])
         else:
             # Check we can verify the test signature independently
-            # this is so taht we can test the ECDSA agaist a known
+            # this is so that we can test the ECDSA against a known
             # good signature
             s.verify(test['signature'])
 
@@ -1783,7 +1783,7 @@ class TestJWT(unittest.TestCase):
         token.make_encrypted_token(key)
         enctok = token.serialize()
 
-        # test workaroud for older applications
+        # test workaround for older applications
         jwt.JWT_expect_type = False
         jwt.JWT(jwt=enctok, key=key)
         jwt.JWT_expect_type = True


### PR DESCRIPTION
[`codespell --ignore-words-list="ect,ser" -w .`](https://pypi.org/project/codespell/)