### PR TITLE
Add Brainpool EC-curves support

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -1053,6 +1053,54 @@ class _A256Gcm(_AesGcm, JWAAlgorithm):
     algorithm_use = 'enc'
 
 
+class _BP256R1(_RawEC, JWAAlgorithm):
+
+    name = "BP256R1"
+    description = (
+        "ECDSA using Brainpool256R1 curve and SHA-256"
+        " (unregistered, custom-defined in breach"
+        " of IETF rules by gematik GmbH)"
+    )
+    keysize = 256
+    algorithm_usage_location = 'alg'
+    algorithm_use = 'sig'
+
+    def __init__(self):
+        super(_BP256R1, self).__init__('BP-256', hashes.SHA256())
+
+
+class _BP384R1(_RawEC, JWAAlgorithm):
+
+    name = "BP384R1"
+    description = (
+        "ECDSA using Brainpool384R1 curve and SHA-384"
+        " (unregistered, custom-defined in breach"
+        " of IETF rules by gematik GmbH)"
+    )
+    keysize = 384
+    algorithm_usage_location = 'alg'
+    algorithm_use = 'sig'
+
+    def __init__(self):
+        super(_BP384R1, self).__init__('BP-384', hashes.SHA384())
+
+
+class _BP512R1(_RawEC, JWAAlgorithm):
+
+    name = "BP512R1"
+    description = (
+        "ECDSA using Brainpool512R1 curve and SHA-512"
+        " (unregistered, custom-defined in breach"
+        " of IETF rules by gematik GmbH)"
+    )
+    keysize = 512
+    algorithm_usage_location = 'alg'
+    algorithm_use = 'sig'
+
+    def __init__(self):
+        super(_BP512R1, self).__init__('BP-512', hashes.SHA512())
+
+
 class JWA:
     """JWA Signing Algorithms.
 
@@ -1097,7 +1145,10 @@ class JWA:
         'A256CBC-HS512': _A256CbcHs512,
         'A128GCM': _A128Gcm,
         'A192GCM': _A192Gcm,
-        'A256GCM': _A256Gcm
+        'A256GCM': _A256Gcm,
+        'BP256R1': _BP256R1,
+        'BP384R1': _BP384R1,
+        'BP512R1': _BP512R1
     }
 
     @classmethod

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -162,7 +162,17 @@ JWKEllipticCurveRegistry = {'P-256': 'P-256 curve',
                             'Ed25519': 'Ed25519 signature algorithm key pairs',
                             'Ed448': 'Ed448 signature algorithm key pairs',
                             'X25519': 'X25519 function key pairs',
-                            'X448': 'X448 function key pairs'}
+                            'X448': 'X448 function key pairs',
+                            'BP-256': 'BrainpoolP256R1 curve'
+                                    ' (unregistered, custom-defined in breach'
+                                    ' of IETF rules by gematik GmbH)',
+                            'BP-384': 'BrainpoolP384R1 curve'
+                                    ' (unregistered, custom-defined in breach'
+                                    ' of IETF rules by gematik GmbH)',
+                            'BP-512': 'BrainpoolP512R1 curve'
+                                    ' (unregistered, custom-defined in breach'
+                                    ' of IETF rules by gematik GmbH)'
+                            }
 """Registry of allowed Elliptic Curves"""
 
 # RFC 7517 - 8.2
@@ -186,7 +196,10 @@ JWKOperationsRegistry = {'sign': 'Compute digital Signature or MAC',
 JWKpycaCurveMap = {'secp256r1': 'P-256',
                    'secp384r1': 'P-384',
                    'secp521r1': 'P-521',
-                   'secp256k1': 'secp256k1'}
+                   'secp256k1': 'secp256k1',
+                   'brainpoolP256r1': 'BP-256',
+                   'brainpoolP384r1': 'BP-384',
+                   'brainpoolP512r1': 'BP-512'}
 
 IANANamedInformationHashAlgorithmRegistry = {
     'sha-256': hashes.SHA256(),
@@ -453,6 +466,12 @@ class JWK(dict):
             return ec.SECP521R1()
         elif cname == 'secp256k1':
             return ec.SECP256K1()
+        elif cname == 'BP-256':
+            return ec.BrainpoolP256R1()
+        elif cname == 'BP-384':
+            return ec.BrainpoolP384R1()
+        elif cname == 'BP-512':
+            return ec.BrainpoolP512R1()
         elif cname in _OKP_CURVES_TABLE:
             return _OKP_CURVES_TABLE[cname]
         else:

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -294,7 +294,66 @@ PrivateKeys_secp256k1 = {
             "x": "Ss6na3mcci8Ud4lQrjaB_T40sfKApEcl2RLIWOJdjow",
             "y": "7l9qIKtKPW6oEiOYBt7r22Sm0mtFJU-yBkkvMvpscd8",
             "d": "GYhU2vrYGZrjLZn71Xniqm54Mi53xiYtaTLawzaf9dA"
+        }
+    ]
+}
+
+PublicKeys_brainpool = {
+    "keys": [
+        {
+            "kty": "EC",
+            "crv": "BP-256",
+            "x": "mpkJ29_CYAD0mzQ_MsrbjFMFYtcc9Oxpro37Fa4cLfI",
+            "y": "iBfhNHk0cI73agNpjbKW62dvuVxn7kxp1Sm8oDnzHl8",
         },
+        {
+            "kty": "EC",
+            "crv": "BP-384",
+            "x": ("WZanneaC2Hi3xslA4znJv7otyEdV5dTPzNUvBjBXPM"
+                  "ytf4mRY9JaAITdItjvUTAh"),
+            "y": ("KNLRTNdvUg66aB_TVW4POZkE3q8S0YoQrCzYUrExRDe"
+                  "_BXikkqIama-GYQ3UBOQL"),
+        },
+        {
+            "kty": "EC",
+            "crv": "BP-512",
+            "x": ("aQXpvz7DH9OK5eFNO9dY3BdPY1v0-8Rg9KC322PY1Jy"
+                  "BJq3EhT0uR_-tgbL2E_aGP6k56lF1xIOOtQxo8zziGA"),
+            "y": ("l9XLHHncigOPr5Tvnj_mVzBFv6i7rdBQrLTq3RXZlCC"
+                  "_f_q6L2o79K9IrN_J2wWxAfS8ekuGPGlHZUzK-3D9sA"),
+        }
+    ]
+}
+
+PrivateKeys_brainpool = {
+    "keys": [
+        {
+            "kty": "EC",
+            "crv": "BP-256",
+            "x": "mpkJ29_CYAD0mzQ_MsrbjFMFYtcc9Oxpro37Fa4cLfI",
+            "y": "iBfhNHk0cI73agNpjbKW62dvuVxn7kxp1Sm8oDnzHl8",
+            "d": "KdKRgq0WEM97BQw3jpW_fTOep6fn-Samv4DfDNb-4s4"
+        },
+        {
+            "kty": "EC",
+            "crv": "BP-384",
+            "x": ("WZanneaC2Hi3xslA4znJv7otyEdV5dTPzNUvBjBXPM"
+                  "ytf4mRY9JaAITdItjvUTAh"),
+            "y": ("KNLRTNdvUg66aB_TVW4POZkE3q8S0YoQrCzYUrExRDe"
+                  "_BXikkqIama-GYQ3UBOQL"),
+            "d": ("B5WeRV0-RztAPAhRbphSAUrsIzy-eSfWGSM5FxOQGlJ"
+                  "cq-ECLA_-SIlH7NdWIEJY")
+        },
+        {
+            "kty": "EC",
+            "crv": "BP-512",
+            "x": ("aQXpvz7DH9OK5eFNO9dY3BdPY1v0-8Rg9KC322PY1Jy"
+                  "BJq3EhT0uR_-tgbL2E_aGP6k56lF1xIOOtQxo8zziGA"),
+            "y": ("l9XLHHncigOPr5Tvnj_mVzBFv6i7rdBQrLTq3RXZlCC"
+                  "_f_q6L2o79K9IrN_J2wWxAfS8ekuGPGlHZUzK-3D9sA"),
+            "d": ("F_LJ9rebAjOtxoMUfngIywYsnJlZNjy3gxNAEvHjSkL"
+                  "m6RUUdLXDwc50EMp0LeTh1ku039D5kldK3S9Xi0yKZA")
+        }
     ]
 }
 
@@ -385,6 +444,15 @@ class TestJWK(unittest.TestCase):
         # New secp256k curve
         key = jwk.JWK.generate(kty='EC', curve='secp256k1')
         key.get_op_key('verify', 'secp256k1')
+        # Brainpool256R1 curve
+        key = jwk.JWK.generate(kty='EC', crv='BP-256')
+        key.get_op_key('verify', 'BP-256')
+        # Brainpool384R1 curve
+        key = jwk.JWK.generate(kty='EC', crv='BP-384')
+        key.get_op_key('verify', 'BP-384')
+        # Brainpool256R1 curve
+        key = jwk.JWK.generate(kty='EC', crv='BP-512')
+        key.get_op_key('verify', 'BP-512')
 
     def test_generate_OKP_keys(self):
         for crv in jwk.ImplementedOkpCurves:
@@ -573,6 +641,16 @@ class TestJWK(unittest.TestCase):
 
     def test_create_priKeys_secp256k1(self):
         keylist = PrivateKeys_secp256k1['keys']
+        for key in keylist:
+            jwk.JWK(**key)
+
+    def test_create_pubKeys_brainpool(self):
+        keylist = PublicKeys_brainpool['keys']
+        for key in keylist:
+            jwk.JWK(**key)
+
+    def test_create_priKeys_brainpool(self):
+        keylist = PrivateKeys_brainpool['keys']
         for key in keylist:
             jwk.JWK(**key)
 
@@ -986,6 +1064,31 @@ class TestJWS(unittest.TestCase):
         jws_verify.deserialize(jws_test_serialization_compact)
         jws_verify.verify(key.public())
         self.assertEqual(jws_verify.payload, payload)
+
+    def test_brainpool_signing_and_verification(self):
+        for key_data in PrivateKeys_brainpool['keys']:
+            key = jwk.JWK(**key_data)
+            payload = bytes(bytearray(A1_payload))
+            jws_test = jws.JWS(payload)
+
+            curve_name = key.get('crv')
+            if curve_name == "BP-256":
+                alg = "BP256R1"
+            elif curve_name == "BP-384":
+                alg = "BP384R1"
+            else:
+                alg = "BP512R1"
+
+            jws_test.allowed_algs = [alg]
+            jws_test.add_signature(key, None, json_encode({"alg": alg}), None)
+            jws_test_serialization_compact = jws_test.serialize(compact=True)
+
+            jws_verify = jws.JWS()
+            jws_verify.allowed_algs = [alg]
+            jws_verify.deserialize(jws_test_serialization_compact)
+            jws_verify.verify(key.public())
+
+            self.assertEqual(jws_verify.payload, payload)
 
     def test_jws_issue_224(self):
         key = jwk.JWK().generate(kty='oct')


### PR DESCRIPTION
Hi,

this pull request adds the Brainpool curves support to jwcrypto. Since cryptography already supports the Brainpool curves,
it's more or less just a boilerplate code. I tried to add the test cases in your style too.

In Germany, especially in Healthcare we are obliged to use the Brainpool elliptic curves, additionally to NIST P-xxx. 

https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03116/BSI-TR-03116-5.pdf?__blob=publicationFile&v=4

https://fachportal.gematik.de/fachportal-import/files/gemSpec_IDP_Dienst_V1.4.0.pdf

