### PR TITLE
chore: refactor for removing pdb symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cscope.out
 .tox
 .coverage
 *.egg-info
+env

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -525,17 +525,17 @@ class JWE:
                         o['header'] = json_encode(djwe['header'])
 
             except ValueError as e:
-                c = raw_jwe.split('.')
-                if len(c) != 5:
+                data = raw_jwe.split('.')
+                if len(data) != 5:
                     raise InvalidJWEData() from e
-                p = base64url_decode(c[0])
+                p = base64url_decode(data[0])
                 o['protected'] = p.decode('utf-8')
-                ekey = base64url_decode(c[1])
+                ekey = base64url_decode(data[1])
                 if ekey != b'':
-                    o['encrypted_key'] = base64url_decode(c[1])
-                o['iv'] = base64url_decode(c[2])
-                o['ciphertext'] = base64url_decode(c[3])
-                o['tag'] = base64url_decode(c[4])
+                    o['encrypted_key'] = base64url_decode(data[1])
+                o['iv'] = base64url_decode(data[2])
+                o['ciphertext'] = base64url_decode(data[3])
+                o['tag'] = base64url_decode(data[4])
 
             self.objects = o
 
@@ -581,11 +581,11 @@ class JWE:
         try:
             return self.serialize() == other.serialize()
         except Exception:  # pylint: disable=broad-except
-            a = {'plaintext': self.plaintext}
-            a.update(self.objects)
-            b = {'plaintext': other.plaintext}
-            b.update(other.objects)
-            return a == b
+            data1 = {'plaintext': self.plaintext}
+            data1.update(self.objects)
+            data2 = {'plaintext': other.plaintext}
+            data2.update(other.objects)
+            return data1 == data2
 
     def __str__(self):
         try:

--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -606,11 +606,11 @@ class JWK(dict):
         # check key_ops
         if 'key_ops' in newkey:
             for ko in newkey['key_ops']:
-                c = 0
+                cnt = 0
                 for cko in newkey['key_ops']:
                     if ko == cko:
-                        c += 1
-                if c != 1:
+                        cnt += 1
+                if cnt != 1:
                     raise InvalidJWKValue('Duplicate values in "key_ops"')
 
         # check use/key_ops consistency
@@ -1028,26 +1028,26 @@ class JWK(dict):
         :return: A serialized bytes buffer containing a PEM formatted key.
         :rtype: `bytes`
         """
-        e = serialization.Encoding.PEM
+        enc = serialization.Encoding.PEM
         if private_key:
             if not self.has_private:
                 raise InvalidJWKType("No private key available")
             f = serialization.PrivateFormat.PKCS8
             if password is None:
-                a = serialization.NoEncryption()
+                enc_alg = serialization.NoEncryption()
             elif isinstance(password, bytes):
-                a = serialization.BestAvailableEncryption(password)
+                enc_alg = serialization.BestAvailableEncryption(password)
             elif password is False:
                 raise ValueError("The password must be None or a bytes string")
             else:
                 raise TypeError("The password string must be bytes")
             return self._get_private_key().private_bytes(
-                encoding=e, format=f, encryption_algorithm=a)
+                encoding=enc, format=f, encryption_algorithm=enc_alg)
         else:
             if not self.has_public:
                 raise InvalidJWKType("No public key available")
             f = serialization.PublicFormat.SubjectPublicKeyInfo
-            return self._get_public_key().public_bytes(encoding=e, format=f)
+            return self._get_public_key().public_bytes(encoding=enc, format=f)
 
     @classmethod
     def from_pyca(cls, key):
@@ -1280,6 +1280,7 @@ class JWKSet(dict):
     Creates a special key 'keys' that is of a type derived from 'set'
     The 'keys' attribute accepts only :class:`jwcrypto.jwk.JWK` elements.
     """
+
     def __init__(self, *args, **kwargs):
         super(JWKSet, self).__init__()
         super(JWKSet, self).__setitem__('keys', _JWKkeys())

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -256,20 +256,20 @@ class JWT:
         return self._claims
 
     @claims.setter
-    def claims(self, c):
-        if not isinstance(c, dict):
+    def claims(self, data):
+        if not isinstance(data, dict):
             if not self._reg_claims:
                 # no default_claims, can return immediately
-                self._claims = c
+                self._claims = data
                 return
-            c = json_decode(c)
+            data = json_decode(data)
         else:
             # _add_default_claims modifies its argument
             # so we must always copy it.
-            c = copy.deepcopy(c)
+            data = copy.deepcopy(data)
 
-        self._add_default_claims(c)
-        self._claims = json_encode(c)
+        self._add_default_claims(data)
+        self._claims = json_encode(data)
 
     @property
     def token(self):
@@ -661,10 +661,10 @@ class JWT:
          decryption key, or a (:class:`jwcrypto.jwk.JWKSet`) that
          contains a key indexed by the 'kid' header.
         """
-        c = jwt.count('.')
-        if c == 2:
+        data = jwt.count('.')
+        if data == 2:
             self.token = JWS()
-        elif c == 4:
+        elif data == 4:
             self.token = JWE()
         else:
             raise ValueError("Token format unrecognized")


### PR DESCRIPTION
This PR represents an easy refactor of small parts of the source code where the PDB symbols was used for variable assignments. It simply removed the variable names `a`, `c` that are used in PDB to inspect the args and continue the execution.

Closes https://github.com/latchset/jwcrypto/issues/327#issuecomment-1686352603