### PR TITLE
Fix X22519 import/export from PEM

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -971,9 +971,13 @@ class JWK(dict):
             self._import_pyca_pri_ec(key)
         elif isinstance(key, ec.EllipticCurvePublicKey):
             self._import_pyca_pub_ec(key)
-        elif isinstance(key, (Ed25519PrivateKey, Ed448PrivateKey)):
+        elif isinstance(key, (Ed25519PrivateKey,
+                              Ed448PrivateKey,
+                              X25519PrivateKey)):
             self._import_pyca_pri_okp(key)
-        elif isinstance(key, (Ed25519PublicKey, Ed448PublicKey)):
+        elif isinstance(key, (Ed25519PublicKey,
+                              Ed448PublicKey,
+                              X25519PublicKey)):
             self._import_pyca_pub_okp(key)
         else:
             raise InvalidJWKValue('Unknown key object %r' % key)

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -367,6 +367,16 @@ MCowBQYDK2VwAyEAlsRcb1mVVIUcDjNqZU27N+iPXihH1EQDa/O3utHLtqc=
 -----END PUBLIC KEY-----
 """
 
+X25519PrivatePEM = b"""-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VuBCIEIBjAbPTtNY6CUuR5FG1+xb1u5nSRokrNaQYEsgu9O+hP
+-----END PRIVATE KEY-----
+"""
+
+X25519PublicPEM = b"""-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VuAyEAW+m9ugi1psQFx6dtTl6J/XZ4JFP019S+oq4wyAoWPnQ=
+-----END PUBLIC KEY-----
+"""
+
 ECPublicPEM = b"""-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhvGzt82WMJxqTuXCZxnvwrx4enQj
 6xc+erlhbTq8gTMAJBzNRPbpuj4NOwTCwjohrtY0TAkthwTuixuojpGKmw==
@@ -379,6 +389,13 @@ ECPublicJWK = {
     "kty": "EC",
     "x": "hvGzt82WMJxqTuXCZxnvwrx4enQj6xc-erlhbTq8gTM",
     "y": "ACQczUT26bo-DTsEwsI6Ia7WNEwJLYcE7osbqI6Rips"
+}
+
+X25519PublicJWK = {
+    'crv': 'X25519',
+    'kid': '9cgLEZD5VsaV9dUPNehs2pOwxtmH-EWHJY-pC74Wjak',
+    'kty': 'OKP',
+    'x': 'W-m9ugi1psQFx6dtTl6J_XZ4JFP019S-oq4wyAoWPnQ'
 }
 
 
@@ -569,6 +586,11 @@ class TestJWK(unittest.TestCase):
         pub_ec = jwk.JWK.from_pem(ECPublicPEM)
         self.assertEqual(pub_ec.export_to_pem(), ECPublicPEM)
         self.assertEqual(json_decode(pub_ec.export()), ECPublicJWK)
+
+    def test_import_x25519_from_pem(self):
+        pub_x25519 = jwk.JWK.from_pem(X25519PublicPEM)
+        self.assertEqual(pub_x25519.export_to_pem(), X25519PublicPEM)
+        self.assertEqual(json_decode(pub_x25519.export()), X25519PublicJWK)
 
     def test_export_symmetric(self):
         key = jwk.JWK(**SymmetricKeys['keys'][0])


### PR DESCRIPTION
This is a very small change to add the ability to import and export PEM X22519 keys.

I am not sure why the documentation build failed, the suggested solution (add a configuration) seems beyond the scope of this change.

The tests pass locally, for what it's worth:

<details>

<summary>Tox output</summary>

```
$ tox
.pkg: _optional_hooks> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
lint: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/54/jwcrypto-1.5.0.tar.gz
lint: commands[0]> .tox/lint/bin/python -m pylint -d c,r,i,W0613 -r n -f colorized --notes= --disable=star-args ./jwcrypto

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

lint: OK ✔ in 11.39 seconds
py36: skipped because could not find python interpreter with spec(s): py36
py36: SKIP ⚠ in 0.36 seconds
py37: skipped because could not find python interpreter with spec(s): py37
py37: SKIP ⚠ in 0.01 seconds
py38: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/55/jwcrypto-1.5.0.tar.gz
py38: commands[0]> .tox/py38/bin/python -bb -m coverage run -m pytest --capture=no --strict-markers
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.3, pluggy-1.3.0
cachedir: .tox/py38/.pytest_cache
rootdir: /workspaces/jwcrypto
configfile: tox.ini
collected 122 items                                                                                                                                                                                                                                                         

jwcrypto/tests-cookbook.py ...................
jwcrypto/tests.py .......................................................................................................

============================================================================================================================ 122 passed in 2.91s ============================================================================================================================
/workspaces/jwcrypto/.tox/py38/lib/python3.8/site-packages/coverage/inorout.py:507: CoverageWarning: Module tests was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
py38: commands[1]> .tox/py38/bin/python -m coverage report -m
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
jwcrypto/__init__.py             0      0      0      0 100.0%
jwcrypto/common.py             106     19     40     11  76.7%   35, 52->54, 65-66, 81, 83, 123, 125, 141, 159-161, 167, 180, 183-188, 197-201, 206
jwcrypto/jwa.py                735     32    102     32  92.4%   78, 90, 145, 170, 360, 367->369, 378, 448, 470, 510, 512, 515, 520->523, 538, 541, 549, 605, 609, 615, 642, 644, 693, 695, 700, 703, 709, 712, 730, 732, 735, 778, 801, 912, 943
jwcrypto/jwe.py                364     29    186     24  88.9%   61, 63, 117, 127, 149-152, 157, 163, 203, 223, 225, 252, 256->258, 258->260, 296, 300-302, 339->342, 342->344, 355-359, 429, 446, 456, 514->517, 530, 542-543, 551, 558
jwcrypto/jwk.py                763    156    320     41  76.1%   45-47, 53-55, 62, 64-66, 72-74, 230-231, 234, 246-248, 251-259, 271-273, 276-286, 355-356, 365-366, 378-379, 406, 453, 457, 478, 517, 526, 568, 579, 581, 594-595, 604, 608-614, 618-630, 651-652, 674, 695, 699->698, 728, 733, 746->745, 748, 770, 778, 784-786, 800, 805, 811, 871->881, 875-876, 885->895, 889-890, 944->946, 949, 1000, 1009-1011, 1014->1016, 1037-1048, 1052, 1108-1109, 1111, 1123, 1127, 1183-1185, 1188-1203, 1207, 1218->1220, 1221->1225, 1253-1254, 1260-1263, 1276, 1299-1302, 1310, 1313-1315, 1336->1341, 1353-1354, 1357, 1364, 1405-1413
jwcrypto/jws.py                412     48    236     52  84.0%   48, 50, 63->65, 66, 82, 84, 120, 142, 149, 210, 222->239, 232, 237, 243, 245->248, 247, 249, 254, 264, 268, 273->272, 279, 282, 298-302, 317, 326, 378, 381, 406, 413, 451->469, 455, 460, 463->466, 471-472, 529-530, 534, 556->558, 558->560, 560->562, 584, 587, 589, 593, 597, 604, 607->613, 635, 643, 651, 664, 673, 678
jwcrypto/jwt.py                439     95    245     44  74.4%   51, 53, 65-72, 82-89, 103, 105, 116-123, 135-142, 155, 159, 236, 248, 283, 287, 291, 299, 308-309, 317->331, 324-326, 328, 330, 339->369, 341->369, 348-363, 365-366, 368, 375-382, 389, 393, 400, 405, 410, 429, 437, 440, 448-449, 458-459, 476, 496, 499, 511, 515, 520->509, 524, 546-549, 552->509, 585, 616, 630, 637, 638->640, 670, 698, 722
jwcrypto/tests-cookbook.py     419      0      0      0 100.0%
jwcrypto/tests.py             1125     30     60      4  96.6%   1069->1071, 1484->exit, 1557-1591, 2141
------------------------------------------------------------------------
TOTAL                         4363    409   1189    208  86.7%
py38: OK ✔ in 5.61 seconds
py39: skipped because could not find python interpreter with spec(s): py39
py39: SKIP ⚠ in 0.01 seconds
py310: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/56/jwcrypto-1.5.0.tar.gz
py310: commands[0]> .tox/py310/bin/python -bb -m coverage run -m pytest --capture=no --strict-markers
============================================================================================================================ test session starts ============================================================================================================================
platform linux -- Python 3.10.8, pytest-7.4.3, pluggy-1.3.0
cachedir: .tox/py310/.pytest_cache
rootdir: /workspaces/jwcrypto
configfile: tox.ini
collected 122 items                                                                                                                                                                                                                                                         

jwcrypto/tests-cookbook.py ...................
jwcrypto/tests.py .......................................................................................................

============================================================================================================================ 122 passed in 2.70s ============================================================================================================================
/workspaces/jwcrypto/.tox/py310/lib/python3.10/site-packages/coverage/inorout.py:507: CoverageWarning: Module tests was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
py310: commands[1]> .tox/py310/bin/python -m coverage report -m
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
jwcrypto/__init__.py             0      0      0      0 100.0%
jwcrypto/common.py             106     19     40     11  76.7%   35, 52->54, 65-66, 81, 83, 123, 125, 141, 159-161, 167, 180, 183-188, 197-201, 206
jwcrypto/jwa.py                735     32    102     32  92.4%   78, 90, 145, 170, 360, 367->369, 378, 448, 470, 510, 512, 515, 520->523, 538, 541, 549, 605, 609, 615, 642, 644, 693, 695, 700, 703, 709, 712, 730, 732, 735, 778, 801, 912, 943
jwcrypto/jwe.py                366     29    186     24  88.9%   61, 63, 117, 127, 149-152, 157, 163, 203, 223, 225, 252, 256->258, 258->260, 296, 300-302, 339->342, 342->344, 355-359, 429, 446, 456, 514->517, 530, 542-543, 551, 558
jwcrypto/jwk.py                769    156    320     41  76.2%   45-47, 53-55, 62, 64-66, 72-74, 230-231, 234, 246-248, 251-259, 271-273, 276-286, 355-356, 365-366, 378-379, 406, 453, 457, 478, 517, 526, 568, 579, 581, 594-595, 604, 608-614, 618-630, 651-652, 674, 695, 699->698, 728, 733, 746->745, 748, 770, 778, 784-786, 800, 805, 811, 871->881, 875-876, 885->895, 889-890, 944->946, 949, 1000, 1009-1011, 1014->1016, 1037-1048, 1052, 1108-1109, 1111, 1123, 1127, 1183-1185, 1188-1203, 1207, 1218->1220, 1221->1225, 1253-1254, 1260-1263, 1276, 1299-1302, 1310, 1313-1315, 1336->1341, 1353-1354, 1357, 1364, 1405-1413
jwcrypto/jws.py                414     48    236     52  84.0%   48, 50, 63->65, 66, 82, 84, 120, 142, 149, 210, 222->239, 232, 237, 243, 245->248, 247, 249, 254, 264, 268, 273->272, 279, 282, 298-302, 317, 326, 378, 381, 406, 413, 451->469, 455, 460, 463->466, 471-472, 529-530, 534, 556->558, 558->560, 560->562, 584, 587, 589, 593, 597, 604, 607->613, 635, 643, 651, 664, 673, 678
jwcrypto/jwt.py                441     95    245     44  74.5%   51, 53, 65-72, 82-89, 103, 105, 116-123, 135-142, 155, 159, 236, 248, 283, 287, 291, 299, 308-309, 317->331, 324-326, 328, 330, 339->369, 341->369, 348-363, 365-366, 368, 375-382, 389, 393, 400, 405, 410, 429, 437, 440, 448-449, 458-459, 476, 496, 499, 511, 515, 520->509, 524, 546-549, 552->509, 585, 616, 630, 637, 638->640, 670, 698, 722
jwcrypto/tests-cookbook.py     419      0      0      0 100.0%
jwcrypto/tests.py             1125     30    146      4  96.5%   1069->1071, 1484->exit, 1557-1591, 2141
------------------------------------------------------------------------
TOTAL                         4375    409   1275    208  86.9%
py310: OK ✔ in 5.17 seconds
pep8: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/57/jwcrypto-1.5.0.tar.gz
pep8: commands[0]> .tox/pep8/bin/python -m flake8 --ignore=N802,N818 jwcrypto
pep8: OK ✔ in 3.09 seconds
doc: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/58/jwcrypto-1.5.0.tar.gz
doc: commands[0]> doc8 --allow-long-titles README.md
Scanning...
Validating...
========
Total files scanned = 0
Total files ignored = 0
Total accumulated errors = 0
doc: commands[1]> markdown_py README.md -f /workspaces/jwcrypto/.tox/README.md.html
doc: OK ✔ in 1.92 seconds
sphinx: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/59/jwcrypto-1.5.0.tar.gz
sphinx: commands[0] /workspaces/jwcrypto/docs/source> sphinx-build -n -v -W -b html -d /workspaces/jwcrypto/.tox/sphinx/tmp/doctrees . /workspaces/jwcrypto/.tox/sphinx/tmp/html
Running Sphinx v7.2.6
making output directory... done
locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 6 source files that are out of date
updating environment: locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
[new config] 6 added, 0 changed, 0 removed
reading sources... [ 17%] common
reading sources... [ 33%] index
reading sources... [ 50%] jwe
reading sources... [ 67%] jwk
reading sources... [ 83%] jws
reading sources... [100%] jwt

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [ 17%] common
writing output... [ 33%] index
writing output... [ 50%] jwe
writing output... [ 67%] jwk
writing output... [ 83%] jws
writing output... [100%] jwt

generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in ../../.tox/sphinx/tmp/html.
sphinx: OK ✔ in 3.9 seconds
doctest: install_package> python -I -m pip install --force-reinstall --no-deps /workspaces/jwcrypto/.tox/.tmp/package/60/jwcrypto-1.5.0.tar.gz
doctest: commands[0] /workspaces/jwcrypto/docs/source> sphinx-build -v -W -b doctest -d /workspaces/jwcrypto/.tox/doctest/tmp/doctrees . /workspaces/jwcrypto/.tox/doctest/tmp/doctest
Running Sphinx v7.2.6
making output directory... done
locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [doctest]: targets for 6 source files that are out of date
updating environment: locale_dir /workspaces/jwcrypto/docs/source/locales/en/LC_MESSAGES does not exist
[new config] 6 added, 0 changed, 0 removed
reading sources... [ 17%] common
reading sources... [ 33%] index
reading sources... [ 50%] jwe
reading sources... [ 67%] jwk
reading sources... [ 83%] jws
reading sources... [100%] jwt

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
running tests...

Document: jws
-------------
1 items passed all tests:
  11 tests in default
11 tests in 1 items.
11 passed and 0 failed.
Test passed.

Document: jwk
-------------
1 items passed all tests:
   8 tests in default
8 tests in 1 items.
8 passed and 0 failed.
Test passed.

Document: jwe
-------------
1 items passed all tests:
  23 tests in default
23 tests in 1 items.
23 passed and 0 failed.
Test passed.

Document: jwt
-------------
1 items passed all tests:
  16 tests in default
16 tests in 1 items.
16 passed and 0 failed.
Test passed.

Doctest summary
===============
   58 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded.

Testing of doctests in the sources finished, look at the results in ../../.tox/doctest/tmp/doctest/output.txt.
.pkg: _exit> python /usr/local/python/3.10.8/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  lint: OK (11.39=setup[2.44]+cmd[8.95] seconds)
  py36: SKIP (0.36 seconds)
  py37: SKIP (0.01 seconds)
  py38: OK (5.61=setup[1.54]+cmd[3.46,0.62] seconds)
  py39: SKIP (0.01 seconds)
  py310: OK (5.17=setup[1.20]+cmd[3.27,0.69] seconds)
  pep8: OK (3.09=setup[1.25]+cmd[1.83] seconds)
  doc: OK (1.92=setup[1.58]+cmd[0.23,0.10] seconds)
  sphinx: OK (3.90=setup[1.25]+cmd[2.66] seconds)
  doctest: OK (3.89=setup[1.39]+cmd[2.50] seconds)
  congratulations :) (37.42 seconds)
```

</summary>