### PR TITLE
Fix potential DoS issue with p2c header

### DIFF
--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -28,6 +28,8 @@ from jwcrypto.jwk import JWK
 
 # Implements RFC 7518 - JSON Web Algorithms (JWA)
 
+default_max_pbkdf2_iterations = 16384
+
 
 class JWAAlgorithm(metaclass=ABCMeta):
 
@@ -588,6 +590,9 @@ class _Pbes2HsAesKw(_RawKeyMgmt):
         self.aeskwmap = {128: _A128KW, 192: _A192KW, 256: _A256KW}
 
     def _get_key(self, alg, key, p2s, p2c):
+        if p2c > default_max_pbkdf2_iterations:
+            raise ValueError('Invalid p2c value, too large')
+
         if not isinstance(key, JWK):
             # backwards compatibility for old interface
             if isinstance(key, bytes):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -2099,6 +2099,18 @@ class ConformanceTests(unittest.TestCase):
         key = jwk.JWK.from_password('password')
         self.assertRaises(ValueError, enc.add_recipient, key)
 
+        # Test p2c iteration checks
+        maxiter = jwa.default_max_pbkdf2_iterations
+        p2cenc = jwe.JWE(plaintext='plain',
+                         protected={"alg": "PBES2-HS256+A128KW",
+                                    "enc": "A256CBC-HS512",
+                                    "p2c": maxiter + 1,
+                                    "p2s": base64url_encode("A" * 16)})
+        with self.assertRaisesRegex(ValueError, 'too large'):
+            p2cenc.add_recipient(key)
+        jwa.default_max_pbkdf2_iterations += 2
+        p2cenc.add_recipient(key)
+
 
 class JWATests(unittest.TestCase):
     def test_jwa_create(self):


### PR DESCRIPTION
Unbounded p2c headers may be used to cause an application that accept PBES algorithms to spend alot of resources running PBKDF2 with a very high number of iterations.

Clamp the default maximum to 16384 (double the default of 8192). An application that wants to use more iterations will have to chenge the jwa default max.

Fixes CVE-2023-6681