### PR TITLE
Fix doc generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+cryptography >= 3.4
+typing_extensions >= 4.5.0


### PR DESCRIPTION
Missing requirements caused the build to fail to include autogenerated doc text.

Fixes #344 