### PR TITLE
Allow to pass through pem loading unsafe option

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -339,6 +339,7 @@ class JWK(dict):
         super(JWK, self).__init__()
         self._cache_pub_k = None
         self._cache_pri_k = None
+        self.unsafe_skip_rsa_key_validation = False
 
         if 'generate' in kwargs:
             self.generate_key(**kwargs)
@@ -838,7 +839,9 @@ class JWK(dict):
     def _rsa_pri(self):
         k = self._cache_pri_k
         if k is None:
-            k = self._rsa_pri_n().private_key(default_backend())
+            u = self.unsafe_skip_rsa_key_validation
+            k = self._rsa_pri_n().private_key(default_backend(),
+                                              unsafe_skip_rsa_key_validation=u)
             self._cache_pri_k = k
         return k
 
@@ -993,8 +996,10 @@ class JWK(dict):
         """
 
         try:
+            u = self.unsafe_skip_rsa_key_validation
             key = serialization.load_pem_private_key(
-                data, password=password, backend=default_backend())
+                data, password=password, backend=default_backend(),
+                unsafe_skip_rsa_key_validation=u)
         except ValueError as e:
             if password is not None:
                 raise e

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -757,6 +757,16 @@ class TestJWK(unittest.TestCase):
             "urn:ietf:params:oauth:jwk-thumbprint:sha-256:{}".format(
                 PublicKeys['thumbprints'][1]))
 
+    def test_unsafe_rsa(self):
+        key = jwk.JWK()
+        key.unsafe_skip_rsa_key_validation = True
+        key.import_from_pem(RSAPrivatePEM, password=RSAPrivatePassword)
+        self.assertTrue(key.has_private)
+        # finally check private works
+        s = jws.JWS(payload='plaintext')
+        s.add_signature(key, None, {"alg": "PS256"})
+        s.serialize()
+
 
 # RFC 7515 - A.1
 A1_protected = \


### PR DESCRIPTION
This has some significant performance impact and
is ok to use with trusted keys.

The way to use it is to create or import a JWK, and then set the object property named unsafe_skip_rsa_key_validation to True

Fixes #353