### PR TITLE
Fix list iteration in claim format validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@
                         "python-311",
                         "python-312",
                         "python-313",
+                        "python-314",
                         "doc",
                         "doctest",
                         "sphinx",
@@ -65,38 +66,44 @@
                             "arch": "x64",
                         },
                         {
+                            "name": "python-314",
+                            "python": "3.14",
+                            "toxenv": "py314",
+                            "arch": "x64",
+                        },
+                        {
                             "name": "doc",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "doc",
                             "arch": "x64",
                         },
                         {
                             "name": "doctest",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "doctest",
                             "arch": "x64",
                         },
                         {
                             "name": "sphinx",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "sphinx",
                             "arch": "x64",
                         },
                         {
                             "name": "lint",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "lint",
                             "arch": "x64",
                         },
                         {
                             "name": "pep8",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "pep8",
                             "arch": "x64",
                         },
                         {
                             "name": "codespell",
-                            "python": "3.13",
+                            "python": "3.14",
                             "toxenv": "codespell",
                             "arch": "x64",
                         },
@@ -104,9 +111,9 @@
                 },
             },
             "steps": [
-                { "uses": "actions/checkout@v4" },
+                { "uses": "actions/checkout@v6" },
                 {
-                    "uses": "actions/setup-python@v5",
+                    "uses": "actions/setup-python@v6",
                     "with": {
                         "python-version": "${{ matrix.python }}",
                         "architecture": "${{ matrix.arch }}"

--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -433,7 +433,7 @@ class JWT:
         if name not in claims or claims[name] is None:
             return
         if isinstance(claims[name], list):
-            if any(not isinstance(claim, str) for claim in claims):
+            if any(not isinstance(claim, str) for claim in claims[name]):
                 raise JWTInvalidClaimFormat(
                     "Claim %s contains non StringOrURI types" % (name, ))
         elif not isinstance(claims[name], str):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1895,6 +1895,18 @@ class TestJWT(unittest.TestCase):
                           jwt=sertok, check_claims={"aud": ["nomatch",
                                                             "failmatch"]})
 
+    def test_claim_aud(self):
+        claims = {"aud": "www.example.com"}
+        key = jwk.JWK(generate='oct', size=256)
+        token = jwt.JWT(header={"alg": "HS256"}, claims=claims)
+        token.make_signed_token(key)
+        sertok = token.serialize()
+        check_claim = {"aud": ["www.example.com", 123]}
+        self.assertRaises(jwt.JWTInvalidClaimFormat, jwt.JWT, key=key,
+                          jwt=sertok, check_claims=check_claim)
+        check_claim = {"aud": ["www.example.com", "123"]}
+        jwt.JWT(key=key, jwt=sertok, check_claims=check_claim)
+
     def test_unexpected(self):
         key = jwk.JWK(generate='oct', size=256)
         claims = {"testclaim": "test"}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py38,py39,py310,py311,py312,py313,pep8,doc,sphinx,doctest
+envlist = lint,py38,py39,py310,py311,py312,py313,py314,pep8,doc,sphinx,doctest
 skip_missing_interpreters = true
 
 [testenv]
@@ -16,7 +16,7 @@ commands =
     {envpython} -m coverage report -m
 
 [testenv:lint]
-basepython = python3.13
+basepython = python3.14
 deps =
     pylint
 #sitepackages = True
@@ -24,7 +24,7 @@ commands =
     {envpython} -m pylint -d c,r,i,W0613 -r n -f colorized --notes= --disable=star-args ./jwcrypto
 
 [testenv:pep8]
-basepython = python3.13
+basepython = python3.14
 deps =
     flake8
     flake8-import-order
@@ -37,13 +37,13 @@ deps =
     doc8
     docutils
     markdown
-basepython = python3.13
+basepython = python3.14
 commands =
     doc8 --allow-long-titles README.md
     markdown_py README.md -f {toxworkdir}/README.md.html
 
 [testenv:sphinx]
-basepython = python3.13
+basepython = python3.14
 changedir = docs/source
 deps =
     sphinx
@@ -52,7 +52,7 @@ commands =
     sphinx-build -n -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:doctest]
-basepython = python3.13
+basepython = python3.14
 changedir = docs/source
 deps =
     sphinx
@@ -60,7 +60,7 @@ commands =
     sphinx-build -v -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/doctest
 
 [testenv:codespell]
-basepython = python3.13
+basepython = python3.14
 deps =
     codespell
 commands =


### PR DESCRIPTION
Update the validation logic to iterate over the items in claims[name] rather than the claims dictionary itself. This fixes a bug where list-based claims (such as multiple audiences) were not correctly checking if all elements were strings. A test for 'aud' claim type validation has been added to prevent future regressions.

Credit to @0xHunSec for reporting this although it was rejected as a security issue, because this flaw gives no security bypass abilities, it is just a bug.