### PR TITLE
fix: bump minimum cryptography dependency to >= 39.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "cryptography >= 3.4",
+    "cryptography >= 39.0.0",
     "typing_extensions >= 4.5.0",
 ]
 


### PR DESCRIPTION
## Problem

The `unsafe_skip_rsa_key_validation` kwarg used in `jwk.py` at lines 842 and 1000 was added to the `cryptography` library in version 39.0.0 ([PR #7667](https://github.com/pyca/cryptography/pull/7667)).

However, `pyproject.toml` only requires `cryptography >= 3.4`, which means pip can install jwcrypto 1.5.7 with an older cryptography that lacks this parameter, causing:

```
TypeError: load_pem_private_key() got an unexpected keyword argument "unsafe_skip_rsa_key_validation"
```

## Fix

Bump the minimum version in `pyproject.toml`:

```diff
-    "cryptography >= 3.4",
+    "cryptography >= 39.0.0",
```

## Verification

- Confirmed `unsafe_skip_rsa_key_validation` is present in both `load_pem_private_key()` and `RSAPrivateNumbers.private_key()` starting from cryptography 39.0.0
- The parameter name has not changed since introduction (a rename PR #8470 was closed without merging)
- All existing functionality is preserved — this is purely a dependency constraint fix

Fixes #376