### PR TITLE
Wrap JWKSet parsing errors in InvalidJWKValue

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -1356,18 +1356,17 @@ class JWKSet(dict):
         """
         try:
             jwkset = json_decode(keyset)
+            if 'keys' not in jwkset:
+                raise ValueError("'keys' not in set")
+
+            for k, v in jwkset.items():
+                if k == 'keys':
+                    for jwk in v:
+                        self['keys'].add(JWK(**jwk))
+                else:
+                    self[k] = v
         except Exception as e:  # pylint: disable=broad-except
             raise InvalidJWKValue from e
-
-        if 'keys' not in jwkset:
-            raise InvalidJWKValue
-
-        for k, v in jwkset.items():
-            if k == 'keys':
-                for jwk in v:
-                    self['keys'].add(JWK(**jwk))
-            else:
-                self[k] = v
 
     @classmethod
     def from_json(cls, keyset):

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -562,6 +562,21 @@ class TestJWK(unittest.TestCase):
         self.assertEqual(len(ks['keys']), 2)
         self.assertEqual(len(ks['keys']), len(ks2['keys']))
 
+    def test_import_keyset_invalid(self):
+        ks = jwk.JWKSet()
+        invalid_inputs = [
+            '',
+            'null',
+            '[]',
+            '{}',
+            '{"keys": 1}',
+            '{"keys": [1]}',
+            '{"keys": [{"kty": "invalid"}]}'
+        ]
+        for inp in invalid_inputs:
+            with self.assertRaises(jwk.InvalidJWKValue):
+                ks.import_keyset(inp)
+
     def test_thumbprint(self):
         for i in range(0, len(PublicKeys['keys'])):
             k = jwk.JWK(**PublicKeys['keys'][i])


### PR DESCRIPTION
Moved the dictionary iteration and key creation logic inside the try-except block. This ensures that any exceptions raised during the instantiation of individual JWK objects or validation checks are properly caught and safely re- raised as an InvalidJWKValue exception, rather than leaking unhandled errors.

Fixes: #378 