### PR TITLE
jwt: add opt-in strict_serialization to enforce compact form

### DIFF
--- a/jwcrypto/jwt.py
+++ b/jwcrypto/jwt.py
@@ -168,7 +168,7 @@ class JWT:
 
     def __init__(self, header=None, claims=None, jwt=None, key=None,
                  algs=None, default_claims=None, check_claims=None,
-                 expected_type=None):
+                 expected_type=None, strict_serialization=False):
         """Creates a JWT object.
 
         :param header: A dict or a JSON string with the JWT Header data.
@@ -190,6 +190,13 @@ class JWT:
          If left to None the code will try to detect what the expected
          type is based on other parameters like 'algs' and will default
          to JWS if no hints are found. It has no effect on token creation.
+        :param strict_serialization: An optional boolean (default False).
+         RFC 7519 mandates that a JWT uses the JWS/JWE Compact
+         Serialization. When set to True any token presented in the
+         JWS/JWE JSON Serialization is rejected at deserialization time,
+         so only the compact representation is accepted. The default is
+         False to preserve backwards compatibility. It has no effect on
+         token creation, which always produces the compact serialization.
 
         Note: either the header,claims or jwt,key parameters should be
         provided as a deserialization operation (which occurs if the jwt
@@ -212,6 +219,7 @@ class JWT:
         self._validity = 600  # 10 minutes validity (up to 11 with leeway)
         self.deserializelog = None
         self._expected_type = expected_type
+        self._strict_serialization = strict_serialization
 
         if header:
             self.header = header
@@ -670,6 +678,18 @@ class JWT:
         self.claims = payload
         self._check_provided_claims()
 
+    @staticmethod
+    def _is_json_serialization(jwt):
+        # The JWS/JWE Compact Serialization is a sequence of base64url
+        # encoded parts joined by dots, so it never decodes as a JSON
+        # object. The JWS/JWE JSON Serialization always is a JSON object.
+        # This mirrors how JWS.deserialize and JWE.deserialize themselves
+        # tell the two representations apart.
+        try:
+            return isinstance(json_decode(jwt), dict)
+        except ValueError:
+            return False
+
     def deserialize(self, jwt, key=None):
         """Deserialize a JWT token.
 
@@ -680,7 +700,16 @@ class JWT:
         :param key: A (:class:`jwcrypto.jwk.JWK`) verification or
          decryption key, or a (:class:`jwcrypto.jwk.JWKSet`) that
          contains a key indexed by the 'kid' header.
+
+        :raises ValueError: if strict_serialization is enabled and the
+         token is not in the JWS/JWE Compact Serialization (for example
+         when a JSON Serialization is provided).
         """
+        if self._strict_serialization and self._is_json_serialization(jwt):
+            raise ValueError("Only the JWS/JWE Compact Serialization is "
+                             "allowed for JWTs (RFC 7519), but a JSON "
+                             "Serialization was provided")
+
         data = jwt.count('.')
         if data == 2:
             self.token = JWS()

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -2537,6 +2537,74 @@ class TestOverloadedOperators(unittest.TestCase):
                   'algs=None, default_claims=None, check_claims=None)'
         self.assertEqual(repr(token), reprrep)
 
+    def test_jwt_strict_serialization_jws(self):
+        # RFC 7519 mandates the Compact Serialization for JWTs. With the
+        # opt-in strict_serialization flag a JSON-serialized JWS must be
+        # rejected, while the compact one keeps working. Without the flag
+        # the previous (lenient) behavior is preserved.
+        key = jwk.JWK.generate(kty='oct', size=256)
+        signer = jws.JWS(payload='{"sub":"alice"}')
+        # The unprotected header carries a dotted value so that the JSON
+        # serialization happens to contain exactly two '.' characters and
+        # is therefore routed to the JWS branch by the legacy dot-count
+        # heuristic. This is the case the lenient path used to accept.
+        signer.add_signature(key, alg='HS256',
+                             protected='{"alg":"HS256"}',
+                             header={'kid': 'a.b.c'})
+        json_token = signer.serialize(compact=False)
+        compact_token = signer.serialize(compact=True)
+
+        # Default behavior is unchanged: the JSON serialization is accepted.
+        lenient = jwt.JWT()
+        lenient.deserialize(json_token, key)
+        self.assertEqual(json_decode(lenient.claims)['sub'], 'alice')
+
+        # Strict mode rejects the JSON serialization.
+        strict = jwt.JWT(strict_serialization=True)
+        with self.assertRaises(ValueError):
+            strict.deserialize(json_token, key)
+
+        # Strict mode also rejects it through the constructor jwt= path.
+        with self.assertRaises(ValueError):
+            jwt.JWT(jwt=json_token, key=key, check_claims=False,
+                    strict_serialization=True)
+
+        # The compact serialization works in both modes.
+        strict_ok = jwt.JWT(strict_serialization=True)
+        strict_ok.deserialize(compact_token, key)
+        self.assertEqual(json_decode(strict_ok.claims)['sub'], 'alice')
+        lenient_ok = jwt.JWT()
+        lenient_ok.deserialize(compact_token, key)
+        self.assertEqual(json_decode(lenient_ok.claims)['sub'], 'alice')
+
+    def test_jwt_strict_serialization_jwe(self):
+        key = jwk.JWK.generate(kty='oct', size=256)
+        algs = ['A256KW', 'A256CBC-HS512']
+        enc = jwe.JWE(plaintext='{"sub":"bob"}',
+                      protected='{"enc":"A256CBC-HS512"}')
+        # A per-recipient dotted header value yields a JSON serialization
+        # with exactly four '.' characters, routed to the JWE branch.
+        enc.add_recipient(key, header={'alg': 'A256KW', 'kid': 'a.b.c.d.e'})
+        json_token = enc.serialize(compact=False)
+
+        enc2 = jwe.JWE(plaintext='{"sub":"bob"}',
+                       protected='{"alg":"A256KW","enc":"A256CBC-HS512"}')
+        enc2.add_recipient(key)
+        compact_token = enc2.serialize(compact=True)
+
+        # Default behavior is unchanged: JSON serialization is accepted.
+        lenient = jwt.JWT(algs=algs)
+        lenient.deserialize(json_token, key)
+        self.assertEqual(json_decode(lenient.claims)['sub'], 'bob')
+
+        # Strict mode rejects the JSON serialization but accepts compact.
+        strict = jwt.JWT(algs=algs, strict_serialization=True)
+        with self.assertRaises(ValueError):
+            strict.deserialize(json_token, key)
+        strict_ok = jwt.JWT(algs=algs, strict_serialization=True)
+        strict_ok.deserialize(compact_token, key)
+        self.assertEqual(json_decode(strict_ok.claims)['sub'], 'bob')
+
 
 class TestRfc9864(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #342

RFC 7519 (Section 7.1, step 8 and the definition of a JWT) requires that a JWT be represented using the JWS or JWE Compact Serialization. `JWT.deserialize` today decides what to do based on `jwt.count('.')`: two dots route to a `JWS`, four dots to a `JWE`. Because the JWS/JWE `deserialize` methods try `json_decode` first, a JSON-serialized token whose surrounding JSON happens to contain exactly two (JWS) or four (JWE) `.` characters is accepted as a JWT. That is reachable in practice: a dotted value in an unprotected header (`{"kid":"a.b.c"}`) or a per-recipient header lands the count on 2 or 4, so a JSON Serialization gets parsed where only a compact token should be.

As the issue notes this is not a vulnerability on its own, but parsing a representation the spec disallows is extra attack surface that some callers would rather not expose.

## What this changes

A new opt-in `strict_serialization` keyword argument on `JWT` (default `False`). When it is `True`, `deserialize` rejects any JSON-serialized JWS/JWE with a clear `ValueError` and only accepts the compact form. Detection reuses the same `json_decode` check that `JWS.deserialize` / `JWE.deserialize` already use to tell the two representations apart (a complete compact token never decodes to a JSON object).

The default is `False`, so existing behavior is completely unchanged. This mirrors the existing knob style on this class (`expected_type`, the `JWT_expect_type` module flag) and has no effect on token creation, which already only emits the compact serialization.

## Before / after

```python
# A JSON-serialized JWS whose JSON contains exactly two dots
signer = jws.JWS(payload='{"sub":"alice"}')
signer.add_signature(key, alg='HS256', protected='{"alg":"HS256"}',
                     header={'kid': 'a.b.c'})
json_token = signer.serialize(compact=False)

# Default (unchanged): accepted
jwt.JWT().deserialize(json_token, key)            # ok

# Opt-in strict: rejected
jwt.JWT(strict_serialization=True).deserialize(json_token, key)
# ValueError: Only the JWS/JWE Compact Serialization is allowed for JWTs
#             (RFC 7519), but a JSON Serialization was provided

# Compact token still works in both modes
jwt.JWT(strict_serialization=True).deserialize(compact_token, key)  # ok
```

## Tests

Added `test_jwt_strict_serialization_jws` and `test_jwt_strict_serialization_jwe` covering, for both signed and encrypted tokens:
- flag on: JSON serialization rejected (via `deserialize` and via the constructor `jwt=` path), compact accepted
- flag off (default): JSON serialization still accepted, so the change is backward compatible

Full suite is green (`python -m pytest jwcrypto/tests.py`), flake8 clean on the changed files.

I went with an opt-in flag deliberately to avoid changing the default. If you would rather have a differently named argument (for example `serialization=` taking `"compact"` / `"any"`), or want this surfaced as a module-level switch instead, happy to adjust.
