### PR TITLE
Skip unknown kty in JWKSet import per RFC 7517 §5

### DIFF
--- a/jwcrypto/jwk.py
+++ b/jwcrypto/jwk.py
@@ -1504,7 +1504,10 @@ class JWKSet(dict):
             for k, v in jwkset.items():
                 if k == 'keys':
                     for jwk in v:
-                        self['keys'].add(JWK(**jwk))
+                        try:
+                            self['keys'].add(JWK(**jwk))
+                        except InvalidJWKType:
+                            pass
                 else:
                     self[k] = v
         except Exception as e:  # pylint: disable=broad-except

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -572,11 +572,25 @@ class TestJWK(unittest.TestCase):
             '{}',
             '{"keys": 1}',
             '{"keys": [1]}',
-            '{"keys": [{"kty": "invalid"}]}'
         ]
         for inp in invalid_inputs:
             with self.assertRaises(jwk.InvalidJWKValue):
                 ks.import_keyset(inp)
+
+    def test_import_keyset_skips_unknown_kty(self):
+        keyset = '{"keys": [{"kty": "unknown"}, %s]}' % json_encode(
+            PublicKeys['keys'][0])
+        ks = jwk.JWKSet.from_json(keyset)
+        self.assertEqual(len(ks['keys']), 1)
+
+    def test_import_keyset_unknown_kty_then_ec(self):
+        ec_key = PublicKeys['keys'][0]
+        keyset = '{"keys": [{"kty": "future"}, %s]}' % json_encode(ec_key)
+        ks = jwk.JWKSet.from_json(keyset)
+        self.assertEqual(len(ks['keys']), 1)
+        imported = list(ks['keys'])[0]
+        self.assertEqual(imported['kty'], 'EC')
+        self.assertEqual(imported['kid'], ec_key['kid'])
 
     def test_thumbprint(self):
         for i in range(0, len(PublicKeys['keys'])):


### PR DESCRIPTION
RFC 7517 §5 states that implementations SHOULD ignore JWKs with unrecognized kty values. Previously, a single unknown kty would abort the entire keyset import, breaking consumers when providers add post-quantum or other novel key types to their JWKS endpoints.

Fixes: https://github.com/latchset/jwcrypto/issues/385

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>