### PR TITLE
Reject non-empty encrypted key in bare ECDH-ES

### DIFF
--- a/jwcrypto/common.py
+++ b/jwcrypto/common.py
@@ -66,6 +66,24 @@ class InvalidCEKeyLength(JWException):
         super(InvalidCEKeyLength, self).__init__(msg)
 
 
+class InvalidJWEData(JWException):
+    """Invalid JWE Object.
+
+    This exception is raised when the JWE Object is invalid and/or
+    improperly formatted.
+    """
+
+    def __init__(self, message=None, exception=None):
+        msg = None
+        if message:
+            msg = message
+        else:
+            msg = 'Unknown Data Verification Failure'
+        if exception:
+            msg += ' {%s}' % str(exception)
+        super(InvalidJWEData, self).__init__(msg)
+
+
 class InvalidJWEOperation(JWException):
     """Invalid JWS Object.
 

--- a/jwcrypto/jwa.py
+++ b/jwcrypto/jwa.py
@@ -20,6 +20,7 @@ from cryptography.hazmat.primitives.padding import PKCS7
 
 from jwcrypto.common import InvalidCEKeyLength
 from jwcrypto.common import InvalidJWAAlgorithm
+from jwcrypto.common import InvalidJWEData
 from jwcrypto.common import InvalidJWEKeyLength
 from jwcrypto.common import InvalidJWEKeyType
 from jwcrypto.common import InvalidJWEOperation
@@ -764,6 +765,7 @@ class _EcdhEs(_RawKeyMgmt, JWAAlgorithm):
     description = "ECDH-ES using Concat KDF"
     algorithm_usage_location = 'alg'
     algorithm_use = 'kex'
+    allow_ek = False
     keysize = None
 
     def __init__(self):
@@ -844,6 +846,8 @@ class _EcdhEs(_RawKeyMgmt, JWAAlgorithm):
     def unwrap(self, key, bitsize, ek, headers):
         if 'epk' not in headers:
             raise ValueError('Invalid Header, missing "epk" parameter')
+        if len(ek) > 0 and not self.allow_ek:
+            raise InvalidJWEData('Non empty "ek" parameter')
         self._check_key(key)
         dk_size = self.keysize
         if self.keysize is None:
@@ -872,6 +876,7 @@ class _EcdhEsAes128Kw(_EcdhEs):
     keysize = 128
     algorithm_usage_location = 'alg'
     algorithm_use = 'kex'
+    allow_ek = True
 
 
 class _EcdhEsAes192Kw(_EcdhEs):
@@ -881,6 +886,7 @@ class _EcdhEsAes192Kw(_EcdhEs):
     keysize = 192
     algorithm_usage_location = 'alg'
     algorithm_use = 'kex'
+    allow_ek = True
 
 
 class _EcdhEsAes256Kw(_EcdhEs):
@@ -890,6 +896,7 @@ class _EcdhEsAes256Kw(_EcdhEs):
     keysize = 256
     algorithm_usage_location = 'alg'
     algorithm_use = 'kex'
+    allow_ek = True
 
 
 class _EdDsa(_RawJWS, JWAAlgorithm):

--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -3,7 +3,7 @@
 import zlib
 
 from jwcrypto import common
-from jwcrypto.common import JWException, JWKeyNotFound
+from jwcrypto.common import JWKeyNotFound
 from jwcrypto.common import JWSEHeaderParameter, JWSEHeaderRegistry
 from jwcrypto.common import base64url_decode, base64url_encode
 from jwcrypto.common import json_decode, json_encode
@@ -50,26 +50,9 @@ default_allowed_algs = [
 """Default allowed algorithms"""
 
 
-class InvalidJWEData(JWException):
-    """Invalid JWE Object.
-
-    This exception is raised when the JWE Object is invalid and/or
-    improperly formatted.
-    """
-
-    def __init__(self, message=None, exception=None):
-        msg = None
-        if message:
-            msg = message
-        else:
-            msg = 'Unknown Data Verification Failure'
-        if exception:
-            msg += ' {%s}' % str(exception)
-        super(InvalidJWEData, self).__init__(msg)
-
-
 # These have been moved to jwcrypto.common, maintain here for backwards compat
 InvalidCEKeyLength = common.InvalidCEKeyLength
+InvalidJWEData = common.InvalidJWEData
 InvalidJWEKeyLength = common.InvalidJWEKeyLength
 InvalidJWEKeyType = common.InvalidJWEKeyType
 InvalidJWEOperation = common.InvalidJWEOperation

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1530,6 +1530,27 @@ class TestJWE(unittest.TestCase):
             e2.deserialize(enc, x25519key)
             self.assertEqual(e2.payload, plaintext)
 
+    def test_bare_ecdh_with_ek_fails(self):
+        payload = b'test data'
+        key = jwk.JWK.generate(kty='EC', crv='P-256')
+        jwetoken = jwe.JWE(
+            plaintext=payload,
+            protected=json_encode({'alg': 'ECDH-ES', 'enc': 'A128GCM'}))
+        jwetoken.add_recipient(key)
+        serialized = jwetoken.serialize(compact=True)
+        parts = serialized.split('.')
+        parts[1] = base64url_encode(b'bogus')
+        corrupted = '.'.join(parts)
+        with self.assertRaises(jwe.InvalidJWEData):
+            e = jwe.JWE()
+            e.deserialize(corrupted, key)
+
+        parts[1] = ''
+        restored = '.'.join(parts)
+        e = jwe.JWE()
+        e.deserialize(restored, key)
+        self.assertEqual(e.payload, payload)
+
     def test_decrypt_keyset(self):
         ks = jwk.JWKSet()
         key1 = jwk.JWK.generate(kty='oct', alg='A128KW', kid='key1')


### PR DESCRIPTION
In direct key agreement mode (ECDH-ES), the encrypted key component must be empty. An allow_ek flag is introduced to enforce this requirement during unwrapping, raising an InvalidJWEData exception if a non-empty encrypted key is provided for bare ECDH-ES while still permitting it for ECDH-ES key wrap algorithms.

Assisted-by: Gemini:Gemini 3.7 Flash

Originally reported by @kieugiathinhphat