### PR TITLE
Limit dot splits during JWE and JWS parsing

### DIFF
--- a/jwcrypto/jwe.py
+++ b/jwcrypto/jwe.py
@@ -535,7 +535,9 @@ class JWE:
                         o['header'] = json_encode(djwe['header'])
 
             except ValueError as e:
-                data = raw_jwe.split('.')
+                # process up to 5 dots, if we have 5+ dots we get more than 5
+                # chunks and that means we have a malformed JWE
+                data = raw_jwe.split('.', 5)
                 if len(data) != 5:
                     raise InvalidJWEData() from e
                 p = base64url_decode(data[0])

--- a/jwcrypto/jws.py
+++ b/jwcrypto/jws.py
@@ -463,7 +463,9 @@ class JWS:
                         o['payload'] = djws['payload']
 
             except ValueError:
-                data = raw_jws.split('.')
+                # process up to 3 dots, if we have 3+ dots we get more than 3
+                # chunks and that means we have a malformed JWS
+                data = raw_jws.split('.', 3)
                 if len(data) != 3:
                     raise InvalidJWSObject('Unrecognized'
                                            ' representation') from None

--- a/jwcrypto/tests.py
+++ b/jwcrypto/tests.py
@@ -1188,6 +1188,23 @@ class TestJWS(unittest.TestCase):
 
         self.assertEqual(header, header_copy)
 
+    def test_compact_invalid_dots(self):
+        key = jwk.JWK.generate(kty='oct', size=256)
+        s = jws.JWS(payload='test')
+        s.add_signature(key, protected={"alg": "HS256"})
+        compact = s.serialize(compact=True)
+        self.assertEqual(compact.count('.'), 2)
+
+        token_3_dots = compact + ".extra"
+        token_10_dots = compact + "." + ".".join(["extra"] * 8)
+
+        j = jws.JWS()
+        with self.assertRaises(jws.InvalidJWSObject):
+            j.deserialize(token_3_dots)
+
+        with self.assertRaises(jws.InvalidJWSObject):
+            j.deserialize(token_10_dots)
+
     def test_decrypt_keyset(self):
         ks = jwk.JWKSet()
         key1 = jwk.JWK.generate(kty='oct', alg='HS256', kid='key1')
@@ -1479,6 +1496,22 @@ class TestJWE(unittest.TestCase):
                         unprotected='{"jku":"https://example.com/keys.jwks"}',
                         recipient=E_A1_ex['key'])
             e.serialize(compact=True)
+
+    def test_compact_invalid_dots(self):
+        e = jwe.JWE(E_A1_ex['plaintext'], E_A1_ex['protected'])
+        e.add_recipient(E_A1_ex['key'])
+        compact = e.serialize(compact=True)
+        self.assertEqual(compact.count('.'), 4)
+
+        token_5_dots = compact + ".extra"
+        token_10_dots = compact + "." + ".".join(["extra"] * 6)
+
+        d = jwe.JWE()
+        with self.assertRaises(jwe.InvalidJWEData):
+            d.deserialize(token_5_dots)
+
+        with self.assertRaises(jwe.InvalidJWEData):
+            d.deserialize(token_10_dots)
 
     def test_JWE_Issue_136(self):
         plaintext = "plain"


### PR DESCRIPTION
When parsing compact JWE and JWS tokens, str.split('.') was previously executed without a maxsplit argument. Malformed tokens containing excessive dots could cause unnecessary memory allocation and processing overhead.

By specifying maxsplit parameters (5 for JWE and 3 for JWS), parsing efficiency is improved and tokens with too many components are quickly rejected as invalid.

Assisted-by: Gemini:Gemini 3.6 Flash